### PR TITLE
feat(generate): inline prompt enhancer toolbar

### DIFF
--- a/src/app/(dashboard)/generate/generate-client.tsx
+++ b/src/app/(dashboard)/generate/generate-client.tsx
@@ -35,7 +35,6 @@ import {
   DollarSign,
   ChevronDown,
   ChevronUp,
-  Zap,
   Image as ImageIcon,
   Video,
   Volume2,
@@ -79,6 +78,7 @@ import {
 } from "@/components/ui/popover";
 import type { promptModifiers as PromptModifiersType } from "@/providers/prompt-improver";
 import { LoraBrowser } from "./lora-browser";
+import { PromptToolbar } from "./prompt-toolbar";
 
 interface GenerateClientProps {
   imageModels: ModelInfo[];
@@ -224,18 +224,23 @@ export function GenerateClient({
 
   // Shared state
   const [prompt, setPrompt] = useState("");
-  const [enhancedPrompt, setEnhancedPrompt] = useState("");
+  const [previousPrompt, setPreviousPrompt] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState(models[0]?.id ?? "");
   const [aspectRatio, setAspectRatio] = useState("1:1");
   const [style, setStyle] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
   const [generatedAsset, setGeneratedAsset] = useState<GeneratedAsset | null>(null);
-  const [enhanceMode, setEnhanceMode] = useState<"template" | "llm">("template");
-  const [template, setTemplate] = useState<PromptTemplate>({});
-  const [showEnhancer, setShowEnhancer] = useState(false);
   const [showModelSelector, setShowModelSelector] = useState(true);
   const [imageLoaded, setImageLoaded] = useState(false);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const promptRef = useRef<HTMLTextAreaElement | null>(null);
+  const [shortcutLabel, setShortcutLabel] = useState("Ctrl+E");
+
+  useEffect(() => {
+    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    setShortcutLabel(isMac ? "⌘E" : "Ctrl+E");
+  }, []);
 
   // Brands (FR-007 / FR-027)
   const [brands, setBrands] = useState<BrandOption[]>([]);
@@ -652,11 +657,22 @@ export function GenerateClient({
     setImageInputPreviews((prev) => prev.filter((_, i) => i !== index));
   }
 
-  async function handleEnhance() {
+  function clearUndoTimer() {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+  }
+
+  async function handleEnhance(
+    mode: "template" | "llm",
+    template: PromptTemplate
+  ) {
     if (!prompt.trim()) {
       toast.error("Enter a prompt first");
       return;
     }
+    const original = prompt;
     setIsEnhancing(true);
     try {
       const res = await fetch("/api/generate/enhance", {
@@ -664,21 +680,42 @@ export function GenerateClient({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           prompt,
-          mode: enhanceMode,
+          mode,
           model: selectedModel,
-          template: enhanceMode === "template" ? template : undefined,
+          template: mode === "template" ? template : undefined,
         }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
-      setEnhancedPrompt(data.enhanced);
-      toast.success("Prompt enhanced");
+      setPreviousPrompt(original);
+      setPrompt(data.enhanced);
+      clearUndoTimer();
+      undoTimerRef.current = setTimeout(() => {
+        setPreviousPrompt(null);
+        undoTimerRef.current = null;
+      }, 8000);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Enhancement failed");
     } finally {
       setIsEnhancing(false);
     }
   }
+
+  function handleUndoEnhance() {
+    if (previousPrompt === null) return;
+    setPrompt(previousPrompt);
+    setPreviousPrompt(null);
+    clearUndoTimer();
+  }
+
+  function handleDismissUndo() {
+    setPreviousPrompt(null);
+    clearUndoTimer();
+  }
+
+  useEffect(() => {
+    return () => clearUndoTimer();
+  }, []);
 
   async function handleGenerate() {
     if (!prompt.trim()) {
@@ -695,7 +732,6 @@ export function GenerateClient({
     try {
       const body: Record<string, unknown> = {
         prompt,
-        enhancedPrompt: enhancedPrompt || undefined,
         model: selectedModel,
         aspectRatio,
         style: style || undefined,
@@ -791,7 +827,8 @@ export function GenerateClient({
     setImageLoaded(false);
     if (clearPrompt) {
       setPrompt("");
-      setEnhancedPrompt("");
+      setPreviousPrompt(null);
+      clearUndoTimer();
       setImageInputs([]);
       setImageInputPreviews([]);
       setAssetBrands([]);
@@ -832,7 +869,6 @@ export function GenerateClient({
           description: brewDescription.trim() || undefined,
           model: selectedModel,
           prompt: brewIncludePrompt ? prompt : undefined,
-          enhancedPrompt: brewIncludePrompt ? enhancedPrompt : undefined,
           parameters: params,
           previewUrl: generatedAsset?.url,
           imageInput: imageInputs.length > 0 ? imageInputs : undefined,
@@ -864,9 +900,13 @@ export function GenerateClient({
     if (isBrewVideo) setMediaType("video");
     else setMediaType("image");
 
-    // Set prompt
-    if (brew.prompt) setPrompt(brew.prompt);
-    if (brew.enhancedPrompt) setEnhancedPrompt(brew.enhancedPrompt);
+    // Set prompt — fold legacy enhancedPrompt into the single prompt field
+    const restoredPrompt = brew.enhancedPrompt?.trim()
+      ? brew.enhancedPrompt
+      : brew.prompt;
+    if (restoredPrompt) setPrompt(restoredPrompt);
+    setPreviousPrompt(null);
+    clearUndoTimer();
 
     // Set parameters
     if (params.aspectRatio) setAspectRatio(params.aspectRatio as string);
@@ -1097,8 +1137,14 @@ export function GenerateClient({
         {/* Prompt Input */}
         <Card className="relative overflow-visible">
           <CardContent className="pt-6 space-y-4">
-            <div className="relative">
+            <div
+              className={cn(
+                "relative rounded-lg transition-shadow",
+                isEnhancing && "prompt-enhancing"
+              )}
+            >
               <Textarea
+                ref={promptRef}
                 placeholder={
                   isVideo
                     ? "Describe the video you want to generate..."
@@ -1108,8 +1154,34 @@ export function GenerateClient({
                 onChange={(e) =>
                   setPrompt(e.target.value.slice(0, PROMPT_MAX_LENGTH))
                 }
-                className="min-h-[140px] resize-none text-base leading-relaxed !ring-primary/30 focus-visible:!border-primary/60 focus-visible:shadow-[0_0_15px_-3px] focus-visible:shadow-primary/20"
+                onKeyDown={(e) => {
+                  if (
+                    (e.metaKey || e.ctrlKey) &&
+                    e.key.toLowerCase() === "e" &&
+                    !e.shiftKey &&
+                    !e.altKey
+                  ) {
+                    e.preventDefault();
+                    if (prompt.trim() && !isEnhancing) {
+                      handleEnhance("llm", {});
+                    }
+                  }
+                }}
+                aria-busy={isEnhancing}
+                className="min-h-[140px] resize-none text-base leading-relaxed pb-10 !ring-primary/30 focus-visible:!border-primary/60 focus-visible:shadow-[0_0_15px_-3px] focus-visible:shadow-primary/20"
               />
+              <div className="pointer-events-none absolute bottom-2 left-2 z-10">
+                <PromptToolbar
+                  prompt={prompt}
+                  isEnhancing={isEnhancing}
+                  showUndo={previousPrompt !== null}
+                  onEnhance={(mode, template) => handleEnhance(mode, template)}
+                  onUndo={handleUndoEnhance}
+                  onDismissUndo={handleDismissUndo}
+                  modifiers={modifiers}
+                  shortcutLabel={shortcutLabel}
+                />
+              </div>
               <span className="absolute bottom-2.5 right-3 text-[11px] tabular-nums text-muted-foreground/60 select-none">
                 {prompt.length}/{PROMPT_MAX_LENGTH}
               </span>
@@ -1212,24 +1284,6 @@ export function GenerateClient({
                 </div>
               )}
             </div>
-
-            {enhancedPrompt && (
-              <div className="rounded-lg border border-primary/15 bg-primary/[0.04] p-3.5 space-y-1.5">
-                <div className="flex items-center gap-1.5 text-xs font-medium text-primary">
-                  <Sparkles className="h-3.5 w-3.5" />
-                  Enhanced Prompt
-                </div>
-                <p className="text-sm leading-relaxed text-foreground/80">
-                  {enhancedPrompt}
-                </p>
-                <button
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                  onClick={() => setEnhancedPrompt("")}
-                >
-                  Clear enhancement
-                </button>
-              </div>
-            )}
 
             {/* Active model indicator */}
             {currentModel && (
@@ -1343,117 +1397,6 @@ export function GenerateClient({
               </Button>
             </div>
           </CardContent>
-        </Card>
-
-        {/* Prompt Enhancer */}
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <button
-                onClick={() => setShowEnhancer(!showEnhancer)}
-                className="flex items-center gap-2 text-left group"
-              >
-                <div className="flex h-7 w-7 items-center justify-center rounded-md bg-secondary">
-                  <Sparkles className="h-3.5 w-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-                </div>
-                <CardTitle className="text-sm font-medium group-hover:text-foreground transition-colors">
-                  Prompt Enhancer
-                </CardTitle>
-                {showEnhancer ? (
-                  <ChevronUp className="h-4 w-4 text-muted-foreground" />
-                ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                )}
-              </button>
-              <Switch
-                checked={showEnhancer}
-                onCheckedChange={setShowEnhancer}
-              />
-            </div>
-          </CardHeader>
-          {showEnhancer && (
-            <CardContent className="space-y-4">
-              <Tabs
-                value={enhanceMode}
-                onValueChange={(v) =>
-                  setEnhanceMode((v ?? "template") as "template" | "llm")
-                }
-              >
-                <TabsList className="w-full">
-                  <TabsTrigger value="template" className="flex-1 gap-1.5">
-                    <Zap className="h-3.5 w-3.5" />
-                    Templates
-                  </TabsTrigger>
-                  <TabsTrigger value="llm" className="flex-1 gap-1.5">
-                    <Sparkles className="h-3.5 w-3.5" />
-                    AI Rewrite
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="template" className="space-y-3 mt-3">
-                  {Object.entries(modifiers).map(([category, options]) => (
-                    <div key={category}>
-                      <Label className="text-xs capitalize mb-1.5 block text-muted-foreground">
-                        {category}
-                      </Label>
-                      <Select
-                        value={
-                          template[category as keyof PromptTemplate] ?? ""
-                        }
-                        onValueChange={(v) =>
-                          setTemplate((prev) => ({
-                            ...prev,
-                            [category]: v ?? "",
-                          }))
-                        }
-                      >
-                        <SelectTrigger className="w-full bg-secondary/50 border-border/50">
-                          <SelectValue placeholder={`Select ${category}`} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {options.map((opt) => (
-                            <SelectItem
-                              key={opt.label}
-                              value={opt.value || "none"}
-                            >
-                              {opt.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  ))}
-                </TabsContent>
-
-                <TabsContent value="llm" className="mt-3">
-                  <div className="rounded-lg border border-dashed border-border/60 bg-secondary/30 p-4">
-                    <p className="text-xs text-muted-foreground">
-                      Uses Mistral AI to rewrite your prompt, optimized for the
-                      selected model.
-                    </p>
-                  </div>
-                </TabsContent>
-              </Tabs>
-
-              <Button
-                onClick={handleEnhance}
-                disabled={isEnhancing || !prompt.trim()}
-                variant="secondary"
-                className="w-full border border-border/50"
-              >
-                {isEnhancing ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Sparkles className="mr-2 h-4 w-4" />
-                )}
-                {isEnhancing
-                  ? "Enhancing..."
-                  : enhanceMode === "template"
-                    ? "Apply Template"
-                    : "Enhance with AI"}
-              </Button>
-            </CardContent>
-          )}
         </Card>
 
         {/* LoRA Browser — shown when model supports LoRAs */}

--- a/src/app/(dashboard)/generate/prompt-toolbar.tsx
+++ b/src/app/(dashboard)/generate/prompt-toolbar.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Sparkles,
+  ChevronDown,
+  Loader2,
+  Wand2,
+  Undo2,
+  Zap,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import type { PromptTemplate } from "@/types";
+import type { promptModifiers as PromptModifiersType } from "@/providers/prompt-improver";
+
+type EnhanceMode = "llm" | "template";
+
+interface PromptToolbarProps {
+  prompt: string;
+  isEnhancing: boolean;
+  showUndo: boolean;
+  onEnhance: (mode: EnhanceMode, template: PromptTemplate) => void;
+  onUndo: () => void;
+  onDismissUndo: () => void;
+  modifiers: typeof PromptModifiersType;
+  shortcutLabel: string;
+}
+
+export function PromptToolbar({
+  prompt,
+  isEnhancing,
+  showUndo,
+  onEnhance,
+  onUndo,
+  onDismissUndo,
+  modifiers,
+  shortcutLabel,
+}: PromptToolbarProps) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<EnhanceMode>("llm");
+  const [template, setTemplate] = useState<PromptTemplate>({});
+  const isMobile = useIsMobile();
+  const disabled = !prompt.trim() || isEnhancing;
+
+  const hasTemplateValues = Object.values(template).some((v) => v && v !== "none");
+
+  function trigger(activeMode: EnhanceMode) {
+    if (disabled) return;
+    onEnhance(activeMode, activeMode === "template" ? template : {});
+    if (activeMode === "template") setTemplate({});
+    setOpen(false);
+  }
+
+  if (showUndo) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-auto relative flex items-center gap-1 overflow-hidden rounded-full border border-primary/30 bg-primary/[0.08] px-1 pl-3 pr-1 py-0.5 text-[11px] font-medium text-primary shadow-sm backdrop-blur-sm"
+      >
+        <Sparkles className="h-3 w-3 shrink-0 opacity-80" />
+        <span className="select-none">Prompt enhanced</span>
+        <button
+          type="button"
+          onClick={onUndo}
+          className="ml-1 flex h-5 items-center gap-1 rounded-full bg-primary/15 px-2 text-[11px] font-semibold text-primary transition-colors hover:bg-primary/25 cursor-pointer"
+        >
+          <Undo2 className="h-3 w-3" />
+          Undo
+        </button>
+        <button
+          type="button"
+          onClick={onDismissUndo}
+          aria-label="Dismiss"
+          className="ml-0.5 flex h-5 w-5 items-center justify-center rounded-full text-primary/70 transition-colors hover:bg-primary/15 hover:text-primary cursor-pointer"
+        >
+          <X className="h-3 w-3" />
+        </button>
+        <span
+          aria-hidden="true"
+          className="undo-progress absolute inset-x-0 bottom-0 h-[2px] bg-primary/60"
+        />
+      </div>
+    );
+  }
+
+  const triggerButton = (
+    <div className="pointer-events-auto inline-flex items-center rounded-full border border-primary/25 bg-primary/[0.06] backdrop-blur-sm shadow-[0_1px_0_0_oklch(var(--primary)/0.10)_inset]">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={() => trigger("llm")}
+              disabled={disabled}
+              aria-label={`Enhance prompt (${shortcutLabel})`}
+              className={cn(
+                "group/enh flex items-center gap-1.5 rounded-l-full pl-2.5 pr-2 h-7 text-[12px] font-medium tracking-tight transition-colors cursor-pointer",
+                "text-primary/90 hover:text-primary hover:bg-primary/10",
+                "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+              )}
+            />
+          }
+        >
+          {isEnhancing ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Sparkles className="h-3.5 w-3.5 transition-transform group-hover/enh:rotate-12" />
+          )}
+          <span>{isEnhancing ? "Enhancing" : "Enhance"}</span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-[11px]">
+          AI rewrite ({shortcutLabel})
+        </TooltipContent>
+      </Tooltip>
+      <span aria-hidden className="h-3.5 w-px bg-primary/20" />
+      <PopoverWrapper
+        open={open}
+        onOpenChange={setOpen}
+        isMobile={isMobile}
+        trigger={
+          <button
+            type="button"
+            aria-label="Open enhance options"
+            aria-expanded={open}
+            disabled={isEnhancing || !prompt.trim()}
+            className={cn(
+              "flex items-center justify-center rounded-r-full pl-1 pr-1.5 h-7 text-primary/80 transition-colors cursor-pointer hover:text-primary hover:bg-primary/10",
+              "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+            )}
+          >
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 transition-transform",
+                open && "rotate-180"
+              )}
+            />
+          </button>
+        }
+      >
+        <ToolbarPanel
+          mode={mode}
+          setMode={setMode}
+          template={template}
+          setTemplate={setTemplate}
+          modifiers={modifiers}
+          hasTemplateValues={hasTemplateValues}
+          isEnhancing={isEnhancing}
+          disabled={disabled}
+          onRun={trigger}
+          shortcutLabel={shortcutLabel}
+        />
+      </PopoverWrapper>
+    </div>
+  );
+
+  return triggerButton;
+}
+
+function PopoverWrapper({
+  open,
+  onOpenChange,
+  trigger,
+  children,
+  isMobile,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  trigger: React.ReactElement;
+  children: React.ReactNode;
+  isMobile: boolean;
+}) {
+  if (isMobile) {
+    return (
+      <>
+        <Sheet open={open} onOpenChange={onOpenChange}>
+          <SheetContent
+            side="bottom"
+            className="rounded-t-2xl border-primary/10 bg-popover/95 px-4 pb-6 pt-5 backdrop-blur-md"
+          >
+            <SheetHeader className="px-0 pb-3">
+              <SheetTitle className="flex items-center gap-2 text-base">
+                <Sparkles className="h-4 w-4 text-primary" />
+                Enhance prompt
+              </SheetTitle>
+              <SheetDescription className="text-xs">
+                Choose how you want this prompt rewritten.
+              </SheetDescription>
+            </SheetHeader>
+            {children}
+          </SheetContent>
+        </Sheet>
+        {React.cloneElement(trigger, {
+          onClick: () => onOpenChange(true),
+        } as React.HTMLAttributes<HTMLButtonElement>)}
+      </>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger render={trigger} />
+      <PopoverContent
+        align="start"
+        side="top"
+        sideOffset={10}
+        className="w-[320px] border border-primary/15 bg-popover/95 p-0 backdrop-blur-md"
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ToolbarPanel({
+  mode,
+  setMode,
+  template,
+  setTemplate,
+  modifiers,
+  hasTemplateValues,
+  isEnhancing,
+  disabled,
+  onRun,
+  shortcutLabel,
+}: {
+  mode: EnhanceMode;
+  setMode: (m: EnhanceMode) => void;
+  template: PromptTemplate;
+  setTemplate: (next: PromptTemplate | ((prev: PromptTemplate) => PromptTemplate)) => void;
+  modifiers: typeof PromptModifiersType;
+  hasTemplateValues: boolean;
+  isEnhancing: boolean;
+  disabled: boolean;
+  onRun: (m: EnhanceMode) => void;
+  shortcutLabel: string;
+}) {
+  return (
+    <div className="flex flex-col p-3 gap-3">
+      <div className="inline-flex w-full rounded-full bg-secondary/60 p-0.5 ring-1 ring-border/40">
+        <SegButton
+          active={mode === "llm"}
+          onClick={() => setMode("llm")}
+          icon={<Sparkles className="h-3 w-3" />}
+          label="AI Rewrite"
+        />
+        <SegButton
+          active={mode === "template"}
+          onClick={() => setMode("template")}
+          icon={<Zap className="h-3 w-3" />}
+          label="Templates"
+        />
+      </div>
+
+      {mode === "llm" ? (
+        <div className="rounded-md border border-dashed border-primary/20 bg-primary/[0.03] p-3">
+          <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-primary/80">
+            <Wand2 className="h-3 w-3" />
+            Mistral rewrite
+          </p>
+          <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+            Rewrites your prompt with model-specific phrasing tips for sharper
+            results. Your original is saved — just hit Undo if you don&apos;t like it.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {Object.entries(modifiers).map(([category, options]) => (
+            <div key={category}>
+              <Label className="mb-1 block text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80 capitalize">
+                {category}
+              </Label>
+              <Select
+                value={template[category as keyof PromptTemplate] ?? ""}
+                onValueChange={(v) =>
+                  setTemplate((prev) => ({
+                    ...prev,
+                    [category]: v ?? "",
+                  }))
+                }
+              >
+                <SelectTrigger className="h-7 w-full border-border/50 bg-secondary/40 text-xs">
+                  <SelectValue placeholder={`Select ${category}`} />
+                </SelectTrigger>
+                <SelectContent>
+                  {options.map((opt) => (
+                    <SelectItem key={opt.label} value={opt.value || "none"}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        size="sm"
+        onClick={() => onRun(mode)}
+        disabled={disabled || (mode === "template" && !hasTemplateValues)}
+        className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        {isEnhancing ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Sparkles className="h-3.5 w-3.5" />
+        )}
+        {isEnhancing
+          ? "Enhancing..."
+          : mode === "llm"
+            ? `Rewrite (${shortcutLabel})`
+            : "Apply Template"}
+      </Button>
+    </div>
+  );
+}
+
+function SegButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-medium transition-all cursor-pointer",
+        active
+          ? "bg-background text-foreground shadow-sm ring-1 ring-border/60"
+          : "text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/src/app/api/generate/enhance/route.ts
+++ b/src/app/api/generate/enhance/route.ts
@@ -10,18 +10,7 @@ import type { ModelId, PromptTemplate } from "@/types";
 const enhanceSchema = z.object({
   prompt: z.string().min(1).max(4000),
   mode: z.enum(["template", "llm"]),
-  model: z.enum([
-    "imagen-4",
-    "imagen-flash",
-    "imagen-flash-lite",
-    "grok-imagine",
-    "grok-imagine-pro",
-    "flux-1.1-pro",
-    "flux-dev",
-    "ideogram-3",
-    "recraft-v3",
-    "recraft-20b",
-  ]),
+  model: z.string().min(1).max(64),
   template: z
     .object({
       style: z.string().optional(),

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -21,7 +21,6 @@ import { bootstrapHostedSignup } from "@/lib/workspace/bootstrap";
 
 const generateSchema = z.object({
   prompt: z.string().min(1).max(4000),
-  enhancedPrompt: z.string().optional(),
   model: z.enum([
     // Image models
     "imagen-4",
@@ -155,7 +154,7 @@ export async function POST(req: NextRequest) {
   }
 
   const {
-    prompt, enhancedPrompt, model,
+    prompt, model,
     aspectRatio, style, negativePrompt, quality,
     seed, outputFormat, resolution, guidance, steps, cfgScale,
     renderingSpeed, personGeneration, watermark, promptEnhance, promptOptimizer, loop,
@@ -270,13 +269,14 @@ export async function POST(req: NextRequest) {
     throw err;
   }
   // The original user prompt stays as `assets.prompt` for transparency.
-  // The kit-injected prompt becomes `enhancedPrompt` (overrides any prior
-  // Mistral-enhanced value when the kit added prefix/suffix).
+  // The kit-injected prompt becomes `enhancedPrompt` when the kit added
+  // prefix/suffix; on override we record null so the asset shows just the
+  // user's prompt verbatim.
   const promptForProvider = kitResult.brandKitOverridden
-    ? (enhancedPrompt || prompt)
+    ? prompt
     : kitResult.promptFinal;
   const enhancedPromptForRecord = kitResult.brandKitOverridden
-    ? enhancedPrompt
+    ? null
     : kitResult.promptFinal;
   const imageInputFinal = kitResult.imageInputFinal.length > 0
     ? kitResult.imageInputFinal

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,7 +90,7 @@
   --card-foreground: oklch(0.94 0.008 280);
   --popover: oklch(0.16 0.02 280);
   --popover-foreground: oklch(0.94 0.008 280);
-  --primary: oklch(0.68 0.19 280);
+  --primary: oklch(0.50 0.22 280);
   --primary-foreground: oklch(0.98 0.005 280);
   --secondary: oklch(0.20 0.02 280);
   --secondary-foreground: oklch(0.90 0.01 280);
@@ -109,7 +109,7 @@
   --chart-5: oklch(0.58 0.14 200);
   --sidebar: oklch(0.14 0.022 280);
   --sidebar-foreground: oklch(0.90 0.01 280);
-  --sidebar-primary: oklch(0.68 0.19 280);
+  --sidebar-primary: oklch(0.50 0.22 280);
   --sidebar-primary-foreground: oklch(0.98 0.005 280);
   --sidebar-accent: oklch(0.18 0.02 280);
   --sidebar-accent-foreground: oklch(0.90 0.01 280);
@@ -148,4 +148,36 @@
     transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease,
       box-shadow 0.15s ease, opacity 0.15s ease;
   }
+}
+
+@keyframes promptShimmer {
+  0% {
+    box-shadow:
+      inset 0 0 0 1px oklch(var(--primary) / 0.35),
+      0 0 0 0 oklch(var(--primary) / 0);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px oklch(var(--primary) / 0.65),
+      0 0 22px -6px oklch(var(--primary) / 0.55);
+  }
+  100% {
+    box-shadow:
+      inset 0 0 0 1px oklch(var(--primary) / 0.35),
+      0 0 0 0 oklch(var(--primary) / 0);
+  }
+}
+
+@keyframes undoTimeout {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+.prompt-enhancing {
+  animation: promptShimmer 1.6s ease-in-out infinite;
+}
+
+.undo-progress {
+  transform-origin: left center;
+  animation: undoTimeout 8s linear forwards;
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,24 @@ export type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-04-29",
+    title: "Prompt enhancement is live again",
+    bullets: [
+      "Click ✨ Enhance on the prompt box to rewrite your idea into a more detailed prompt",
+      "Powered by Mistral — set MISTRAL_API_KEY in your env to enable it",
+      "Tuned per model — gpt-image, Imagen, Flux, and video providers get model-specific phrasing tips",
+    ],
+  },
+  {
+    date: "2026-04-29",
+    title: "Cleaner error messages",
+    bullets: [
+      "When a provider rejects a generation, the toast now shows the actual reason instead of the raw API response",
+      "Your prompt and signed asset URLs stay out of error messages",
+      "Applied across every image and video model",
+    ],
+  },
+  {
+    date: "2026-04-29",
     title: "OpenAI image editing",
     bullets: [
       "OpenAI gpt-image models can now edit existing images — drop a reference into Generate and they'll follow your edit prompt directly",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,17 @@ export type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-04-29",
+    title: "Prompt enhancer, redesigned",
+    bullets: [
+      "Enhance now lives inside the prompt box — one tap rewrites your prompt in place, no extra panel to expand",
+      "Hit Cmd/Ctrl+E to rewrite without leaving the keyboard",
+      "Don't love the rewrite? An Undo pill appears for 8 seconds to put your original prompt back",
+      "Click the ▾ next to Enhance for templates (style, lighting, composition, mood, quality) — selections clear after each run so they don't pile up",
+      "On phones the options open as a bottom sheet for easier tapping",
+    ],
+  },
+  {
+    date: "2026-04-29",
     title: "Prompt enhancement is live again",
     bullets: [
       "Click ✨ Enhance on the prompt box to rewrite your idea into a more detailed prompt",


### PR DESCRIPTION
## Summary
- Enhance moved inside the prompt textarea (mirror of the char counter); one click runs AI Rewrite and replaces the prompt in place. Cmd/Ctrl+E shortcut.
- Adds an 8s Undo pill so users can recover their original prompt non-destructively.
- Templates (style/lighting/composition/mood/quality) live behind a caret popover (bottom sheet on mobile) and reset after each run so modifiers don't pile up invisibly.
- Removes the below-the-fold accordion Card and the parallel Enhanced Prompt preview. The textarea is now the single source of truth, so the client no longer sends `enhancedPrompt` to `/api/generate`. Brews with a saved enhanced prompt fold it into `prompt` on load.

## Test plan
- [ ] Empty prompt → Enhance button is disabled
- [ ] Type a prompt → click Enhance → loading shimmer → textarea content is replaced
- [ ] Undo pill appears for ~8s; clicking it restores the original prompt
- [ ] Open the templates popover → choose options → Enhance → templates clear after run
- [ ] Cmd/Ctrl+E triggers Enhance from the keyboard
- [ ] Narrow viewport renders the popover as a bottom sheet
- [ ] Generate still works end-to-end (no `enhancedPrompt` in the request payload)
- [ ] Loading a saved Brew that had an enhanced prompt populates the textarea correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)