### PR TITLE
feat(library-dam): unified Library + workspace scoping + identity affordances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,27 @@ STORAGE_PROVIDER="local"
 
 # Mistral (prompt enhancement)
 # MISTRAL_API_KEY=""
+
+# ============================================
+# LIBRARY / DAM — Embedding pipeline
+# ============================================
+
+# Library/DAM feature flag — when "false" the /library route + /api/library
+# endpoints respond with 404 and the sidebar still points at /references. Flip
+# to "true" once the unified Library is ready to ship to all users.
+LIBRARY_DAM_ENABLED="false"
+
+# Replicate (CLIP image embeddings — andreasjansson/clip-features)
+# Without this token the embedding worker is a no-op; semantic search falls
+# back to text-only.
+# REPLICATE_API_TOKEN=""
+
+# Embedding model identifier persisted on each row so a future model swap is
+# reversible per-asset. Keep in sync with EMBEDDING_DIM.
+EMBEDDING_MODEL="andreasjansson/clip-features"
+EMBEDDING_DIM="768"
+
+# Worker tuning. Batch size is the max rows the cron tick will pull per run;
+# cron interval is the minutes between Vercel cron invocations.
+EMBEDDING_BATCH_SIZE="50"
+EMBEDDING_CRON_INTERVAL_MIN="2"

--- a/drizzle/0016_library_dam_schema.sql
+++ b/drizzle/0016_library_dam_schema.sql
@@ -1,0 +1,239 @@
+-- Migration 0016 — Library / Unified DAM foundation (Phase 2 of specs/library-dam).
+--
+-- Unifies `references` (uploads) and `assets` (generations) into a single
+-- `assets` table with a `source` discriminator, fileName/usageCount carry-over,
+-- pgvector embedding column, generated tsvector for full-text search, and a
+-- one-shot rename of brands.anchor_reference_ids → brands.anchor_asset_ids.
+--
+-- Phase 2 is *additive only* — no existing column is dropped, no table is
+-- removed. The references → assets backfill runs in a separate idempotent
+-- script (`scripts/migrate-references-to-assets.ts`). The `references` table
+-- and the temporary `assets.legacy_reference_id` column drop later, in a
+-- separate migration after the compat-shim release lands (Phase 6 / T043).
+--
+-- Idempotency: every column/index uses IF NOT EXISTS; the brand-anchor
+-- rename and the source-vocabulary update are guarded by information_schema
+-- lookups so re-running the migration is a no-op.
+--
+-- Design notes for searchVector (T008):
+--   * We pick option (a) — denormalized `tags_text` column maintained by
+--     triggers on `asset_tags`. The generated tsvector reads from
+--     `coalesce(file_name,'') || ' ' || coalesce(prompt,'') || ' ' || coalesce(tags_text,'')`.
+--   * Option (b) — refresh `search_vector` directly from a trigger on
+--     `asset_tags` — would require the trigger to emit the same expression
+--     the generated column would have used. By denormalizing the tag string
+--     into its own column, the search_vector definition stays declarative
+--     and the trigger only has one job (rebuild `tags_text`).
+--   * Tradeoff: an extra `text` column on `assets`. Cost is negligible; the
+--     payoff is one source of truth for the FTS expression.
+
+-- 1. pgvector extension. Phase 1 (T001) verified the extension is available
+--    on Neon project `fancy-dew-30879013` (default version 0.8.0). HNSW index
+--    support was added in pgvector 0.5.0, so 0.8.0 covers us.
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
+
+-- 2. Additive columns on `assets`. `source` is intentionally NOT in this list
+--    — Phase 1 found it already exists as a NOT NULL text column populated
+--    with the literal "generation" for every row. We update its vocabulary
+--    in step 8 below instead of re-adding the column.
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "file_name" text;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "usage_count" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "embedding" vector(768);
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "embedding_model" text;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "embedded_at" timestamptz;
+--> statement-breakpoint
+
+-- 3. Temp pointer back to the legacy `references.id` so the backfill is
+--    idempotent (re-runs skip rows where this is already set) and Phase 6
+--    can audit the mapping before the references table drops.
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "legacy_reference_id" uuid;
+--> statement-breakpoint
+
+-- 4. Denormalized tag-name column feeding the generated search_vector.
+--    Maintained by triggers on `asset_tags` declared further down.
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "tags_text" text NOT NULL DEFAULT '';
+--> statement-breakpoint
+
+-- 5. Generated tsvector column. Postgres requires the GENERATED ALWAYS AS
+--    expression to be IMMUTABLE; coalesce + concat over text columns is fine.
+--    The english config matches what the search query will use (see plan.md
+--    "search query path"). Wrap in a DO block so re-runs don't trip on the
+--    "column already exists" error from ADD COLUMN (since the generated-column
+--    syntax doesn't support IF NOT EXISTS).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'assets'
+       AND column_name = 'search_vector'
+  ) THEN
+    ALTER TABLE "assets"
+      ADD COLUMN "search_vector" tsvector
+      GENERATED ALWAYS AS (
+        to_tsvector(
+          'english',
+          coalesce("file_name", '') || ' ' ||
+          coalesce("prompt", '') || ' ' ||
+          coalesce("tags_text", '')
+        )
+      ) STORED;
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- 6. Source-vocabulary rewrite. The live DB has every row at "generation";
+--    the new vocabulary is "uploaded" | "generated" | "imported". Idempotent.
+UPDATE "assets" SET "source" = 'generated' WHERE "source" = 'generation';
+--> statement-breakpoint
+-- A few legacy code paths wrote "upload" / "fork" before deploy; remap them
+-- so the post-migration enum invariant holds. Forks are derivative
+-- generations — they keep `parent_asset_id` but their source becomes
+-- "generated". (No production rows match these per Phase 1 findings; this is
+-- defense-in-depth.)
+UPDATE "assets" SET "source" = 'uploaded' WHERE "source" = 'upload';
+--> statement-breakpoint
+UPDATE "assets" SET "source" = 'generated' WHERE "source" = 'fork';
+--> statement-breakpoint
+-- Update the column default so future raw-SQL inserts (e.g. drizzle-kit
+-- push, manual seed scripts) also land on the new vocabulary. Drizzle ORM
+-- inserts already pass an explicit source so this is defense-in-depth.
+ALTER TABLE "assets" ALTER COLUMN "source" SET DEFAULT 'generated';
+--> statement-breakpoint
+
+-- 7. Brand-anchor column rename: anchor_reference_ids → anchor_asset_ids.
+--    Wrap in a DO block so re-running this migration after the rename is a
+--    no-op (PG's RENAME COLUMN doesn't have an IF EXISTS form).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'brands'
+       AND column_name = 'anchor_reference_ids'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'brands'
+       AND column_name = 'anchor_asset_ids'
+  ) THEN
+    ALTER TABLE "brands" RENAME COLUMN "anchor_reference_ids" TO "anchor_asset_ids";
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- 8. Indexes. Hot paths from plan.md: per-user-feed, brand filter, source
+--    filter, FTS, semantic search.
+CREATE INDEX IF NOT EXISTS "assets_user_id_created_at_idx"
+  ON "assets" ("user_id", "created_at" DESC);
+--> statement-breakpoint
+-- assets_brand_id_idx exists today (created in 0008/0009); IF NOT EXISTS is
+-- a no-op there but keeps the migration idempotent if someone replays it
+-- against a fresh DB that never went through the older migrations.
+CREATE INDEX IF NOT EXISTS "assets_brand_id_idx"
+  ON "assets" ("brand_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "assets_source_idx"
+  ON "assets" ("source");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "assets_search_vector_idx"
+  ON "assets" USING gin ("search_vector");
+--> statement-breakpoint
+-- HNSW on embedding with cosine ops. m=16 / ef_construction=64 per plan.md.
+-- pgvector 0.8.0 supports HNSW directly. The IF NOT EXISTS guard keeps the
+-- migration idempotent; CREATE INDEX with HNSW is non-trivial and we don't
+-- want a re-run to spin it back up.
+CREATE INDEX IF NOT EXISTS "assets_embedding_hnsw_idx"
+  ON "assets" USING hnsw ("embedding" vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+--> statement-breakpoint
+-- Idempotency for the backfill — the script bails on rows whose
+-- legacy_reference_id is already populated.
+CREATE UNIQUE INDEX IF NOT EXISTS "assets_legacy_reference_id_uniq"
+  ON "assets" ("legacy_reference_id")
+  WHERE "legacy_reference_id" IS NOT NULL;
+--> statement-breakpoint
+
+-- 9. Trigger function + triggers maintaining `assets.tags_text`. Three
+--    trigger paths cover every M2M edit:
+--    * INSERT on asset_tags          → recompute for NEW.asset_id
+--    * DELETE on asset_tags          → recompute for OLD.asset_id
+--    * UPDATE on asset_tags          → recompute for both NEW and OLD asset_id
+--      (in practice asset_tags rows are never updated since both columns are
+--       part of the PK, but cover the case for completeness).
+CREATE OR REPLACE FUNCTION "assets_refresh_tags_text"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _asset_id uuid;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    _asset_id := OLD.asset_id;
+  ELSE
+    _asset_id := NEW.asset_id;
+  END IF;
+
+  UPDATE "assets"
+     SET "tags_text" = COALESCE((
+       SELECT string_agg(at.tag, ' ' ORDER BY at.tag)
+         FROM "asset_tags" at
+        WHERE at.asset_id = _asset_id
+     ), '')
+   WHERE "id" = _asset_id;
+
+  -- For UPDATE-of-asset_id (rare; both PK cols), refresh the OLD asset too.
+  IF TG_OP = 'UPDATE' AND OLD.asset_id IS DISTINCT FROM NEW.asset_id THEN
+    UPDATE "assets"
+       SET "tags_text" = COALESCE((
+         SELECT string_agg(at.tag, ' ' ORDER BY at.tag)
+           FROM "asset_tags" at
+          WHERE at.asset_id = OLD.asset_id
+       ), '')
+     WHERE "id" = OLD.asset_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS "asset_tags_refresh_tags_text_ins" ON "asset_tags";
+--> statement-breakpoint
+CREATE TRIGGER "asset_tags_refresh_tags_text_ins"
+  AFTER INSERT ON "asset_tags"
+  FOR EACH ROW EXECUTE FUNCTION "assets_refresh_tags_text"();
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS "asset_tags_refresh_tags_text_del" ON "asset_tags";
+--> statement-breakpoint
+CREATE TRIGGER "asset_tags_refresh_tags_text_del"
+  AFTER DELETE ON "asset_tags"
+  FOR EACH ROW EXECUTE FUNCTION "assets_refresh_tags_text"();
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS "asset_tags_refresh_tags_text_upd" ON "asset_tags";
+--> statement-breakpoint
+CREATE TRIGGER "asset_tags_refresh_tags_text_upd"
+  AFTER UPDATE ON "asset_tags"
+  FOR EACH ROW EXECUTE FUNCTION "assets_refresh_tags_text"();
+--> statement-breakpoint
+
+-- 10. One-shot backfill of tags_text for any existing assets that already
+--     have tag rows (so the generated search_vector is correct from migration
+--     time, not just for future tag edits). Idempotent: rewrites the same
+--     value the trigger would compute.
+UPDATE "assets" a
+   SET "tags_text" = COALESCE(sub.tags_text, '')
+  FROM (
+    SELECT asset_id, string_agg(tag, ' ' ORDER BY tag) AS tags_text
+      FROM "asset_tags"
+     GROUP BY asset_id
+  ) sub
+ WHERE a.id = sub.asset_id
+   AND a."tags_text" IS DISTINCT FROM COALESCE(sub.tags_text, '');

--- a/drizzle/0017_search_vector_normalize.sql
+++ b/drizzle/0017_search_vector_normalize.sql
@@ -1,0 +1,48 @@
+-- Migration 0017 — Normalize search_vector tokens (Phase 4 / FTS bugfix).
+--
+-- 0016 declared `search_vector` as
+--     to_tsvector('english',
+--       coalesce(file_name,'') || ' ' || coalesce(prompt,'') || ' ' || coalesce(tags_text,''))
+-- which works for prompt text but breaks on filenames and tag names that
+-- contain hyphens / underscores / dots. Postgres's default text-search parser
+-- recognises strings like `hero-shot-001.png` as a *single* "host" token, so
+-- `websearch_to_tsquery('english', 'hero')` doesn't match the asset.
+--
+-- Fix: normalise file_name and tags_text by replacing `[-_./]+` with spaces
+-- BEFORE tokenisation, so `hero-shot-001.png` becomes the lexemes
+-- `hero, shot, 001, png` (each individually queryable). `prompt` is left
+-- untouched — it's free-form English where punctuation matters for stemming.
+--
+-- A generated column's expression can't be altered in place; we drop + recreate
+-- around the GIN index that depends on it. Both column and index are recreated
+-- with identical names so the rest of the schema (T025 query handler, the
+-- detection that drives `<FilterBar>` empty states) keeps working unchanged.
+--
+-- Idempotency: every step uses IF EXISTS / IF NOT EXISTS or a DO block that
+-- only mutates when the current state requires it.
+
+-- 1. Drop the GIN index. Generated columns can't be dropped while an index
+--    references them.
+DROP INDEX IF EXISTS "assets_search_vector_idx";
+--> statement-breakpoint
+
+-- 2. Drop the generated column. We're rebuilding it.
+ALTER TABLE "assets" DROP COLUMN IF EXISTS "search_vector";
+--> statement-breakpoint
+
+-- 3. Recreate the generated column with the normalised expression.
+ALTER TABLE "assets"
+  ADD COLUMN "search_vector" tsvector
+  GENERATED ALWAYS AS (
+    to_tsvector(
+      'english',
+      coalesce(regexp_replace("file_name", '[-_./]+', ' ', 'g'), '') || ' ' ||
+      coalesce("prompt", '') || ' ' ||
+      coalesce(regexp_replace("tags_text", '[-_./]+', ' ', 'g'), '')
+    )
+  ) STORED;
+--> statement-breakpoint
+
+-- 4. Recreate the GIN index over the new column.
+CREATE INDEX IF NOT EXISTS "assets_search_vector_idx"
+  ON "assets" USING gin ("search_vector");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777647509000,
       "tag": "0016_library_dam_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777733909000,
+      "tag": "0017_search_vector_normalize",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777561109000,
       "tag": "0015_notifications",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777647509000,
+      "tag": "0016_library_dam_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "bootstrap": "tsx scripts/bootstrap-self-hosted.ts",
-    "verify-migration": "tsx scripts/verify-migration.ts"
+    "verify-migration": "tsx scripts/verify-migration.ts",
+    "migrate-refs": "tsx scripts/migrate-references-to-assets.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",

--- a/scripts/migrate-references-to-assets.ts
+++ b/scripts/migrate-references-to-assets.ts
@@ -1,0 +1,445 @@
+/**
+ * migrate-references-to-assets.ts — Phase 2 (T009) data backfill for the
+ * Library / Unified DAM (specs/library-dam).
+ *
+ * Copies every row from `references` into `assets` (with source='uploaded'),
+ * pairs it with an `uploads` row to preserve mime type + original filename,
+ * and retargets every `brands.anchor_asset_ids` jsonb array from old
+ * reference IDs to the new asset IDs via the `assets.legacy_reference_id`
+ * map. One transaction per user — partial failures roll back per-user, the
+ * rest of the run continues.
+ *
+ * Idempotency:
+ *   - Each insert into `assets` skips rows whose `legacy_reference_id` is
+ *     already present (enforced by the partial unique index from migration
+ *     0016).
+ *   - Each `brands` retarget is skipped when every entry in
+ *     `anchor_asset_ids` already resolves to a valid `assets.id` (i.e. the
+ *     retarget was already applied).
+ *
+ * Safety:
+ *   - If any anchor ID fails to map (it's neither a known reference nor an
+ *     existing asset), the brand is NOT updated. The bad IDs are reported
+ *     in `unmappedAnchorIds`. Per-user transaction rolls back its own
+ *     scope; the script keeps going for other users.
+ *   - If a brand belongs to a different user than the references owner
+ *     being processed, it's skipped and reported in `mismatchedUserScopes`.
+ *
+ * Usage:
+ *   pnpm migrate-refs                       # production-style: writes JSON to stdout
+ *   DATABASE_URL=... pnpm migrate-refs      # explicit DB
+ */
+
+import { Pool, type PoolClient } from "pg";
+import dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+interface ReferenceRow {
+  id: string;
+  user_id: string;
+  brand_id: string | null;
+  r2_key: string;
+  r2_url: string;
+  thumbnail_r2_key: string | null;
+  file_name: string | null;
+  file_size: number | null;
+  width: number | null;
+  height: number | null;
+  mime_type: string;
+  usage_count: number;
+  created_at: Date;
+}
+
+interface BrandRow {
+  id: string;
+  workspace_id: string | null;
+  anchor_asset_ids: string[];
+  // Owners-of-this-brand resolved via brand_members for scope-checking. We
+  // only retarget brands whose member set overlaps with the references'
+  // owner — otherwise we'd be touching another user's brand.
+}
+
+interface VerifierReport {
+  usersProcessed: number;
+  referencesIn: number;
+  assetsInsertedThisRun: number;
+  assetsAlreadyMigrated: number;
+  brandsUpdated: number;
+  anchorIdsRetargeted: number;
+  unmappedAnchorIds: string[];
+  mismatchedUserScopes: string[];
+  errors: Array<{ userId?: string; brandId?: string; message: string }>;
+}
+
+function emptyReport(): VerifierReport {
+  return {
+    usersProcessed: 0,
+    referencesIn: 0,
+    assetsInsertedThisRun: 0,
+    assetsAlreadyMigrated: 0,
+    brandsUpdated: 0,
+    anchorIdsRetargeted: 0,
+    unmappedAnchorIds: [],
+    mismatchedUserScopes: [],
+    errors: [],
+  };
+}
+
+async function listUsersWithReferences(pool: Pool): Promise<string[]> {
+  const { rows } = await pool.query<{ user_id: string }>(
+    `SELECT DISTINCT user_id FROM "references" ORDER BY user_id`
+  );
+  return rows.map((r) => r.user_id);
+}
+
+async function fetchReferencesForUser(
+  client: PoolClient,
+  userId: string
+): Promise<ReferenceRow[]> {
+  const { rows } = await client.query<ReferenceRow>(
+    `SELECT id, user_id, brand_id, r2_key, r2_url, thumbnail_r2_key,
+            file_name, file_size, width, height, mime_type, usage_count,
+            created_at
+       FROM "references"
+      WHERE user_id = $1
+      ORDER BY created_at`,
+    [userId]
+  );
+  return rows;
+}
+
+/**
+ * Resolve the user's Personal brand id. The agency-DAM 0009 migration created
+ * one Personal brand per user; references without an explicit brand fold
+ * into it because `assets.brand_id` is NOT NULL post-0010.
+ *
+ * Returns null if no Personal brand can be found (caller logs an error and
+ * skips that user — should never happen in practice; every user got a
+ * Personal brand in 0009).
+ */
+async function resolvePersonalBrandId(
+  client: PoolClient,
+  userId: string
+): Promise<string | null> {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id FROM "brands"
+      WHERE owner_id = $1 AND is_personal = true
+      ORDER BY created_at ASC
+      LIMIT 1`,
+    [userId]
+  );
+  return rows[0]?.id ?? null;
+}
+
+async function existingLegacyMap(
+  client: PoolClient,
+  userId: string
+): Promise<Map<string, string>> {
+  const { rows } = await client.query<{ id: string; legacy_reference_id: string }>(
+    `SELECT id, legacy_reference_id FROM "assets"
+      WHERE user_id = $1 AND legacy_reference_id IS NOT NULL`,
+    [userId]
+  );
+  const map = new Map<string, string>();
+  for (const r of rows) map.set(r.legacy_reference_id, r.id);
+  return map;
+}
+
+/**
+ * Insert one reference into `assets` + `uploads`. Returns the new asset id,
+ * OR null if the row was already migrated (idempotent skip).
+ */
+async function insertReferenceAsAsset(
+  client: PoolClient,
+  ref: ReferenceRow
+): Promise<{ assetId: string; alreadyMigrated: boolean }> {
+  // Idempotent guard via the partial unique index assets_legacy_reference_id_uniq.
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM "assets" WHERE legacy_reference_id = $1`,
+    [ref.id]
+  );
+  if (existing.rowCount && existing.rows[0]) {
+    return { assetId: existing.rows[0].id, alreadyMigrated: true };
+  }
+
+  // Image-only references (the legacy upload UI gates on this); media_type
+  // = 'image' is correct for every backfilled row.
+  const inserted = await client.query<{ id: string }>(
+    `INSERT INTO "assets" (
+       user_id, brand_id, status, source, brand_kit_overridden, media_type,
+       model, provider, prompt, parameters, r2_key, r2_url, thumbnail_r2_key,
+       file_name, usage_count, width, height, file_size, cost_estimate,
+       legacy_reference_id, created_at
+     ) VALUES (
+       $1, $2, 'draft', 'uploaded', false, 'image',
+       'upload', 'upload', $3, $4, $5, $6, $7,
+       $8, $9, $10, $11, $12, 0,
+       $13, $14
+     )
+     RETURNING id`,
+    [
+      ref.user_id,
+      ref.brand_id,
+      // `prompt` is NOT NULL on assets; the original file name is the most
+      // natural stand-in (the UI shows it as the asset title anyway).
+      ref.file_name ?? "uploaded reference",
+      // Stash original mime in `parameters` so it's preserved without
+      // requiring a new column. The paired uploads row also keeps it.
+      JSON.stringify({
+        originalFilename: ref.file_name,
+        contentType: ref.mime_type,
+        legacyReferenceId: ref.id,
+      }),
+      ref.r2_key,
+      ref.r2_url,
+      ref.thumbnail_r2_key,
+      ref.file_name,
+      ref.usage_count,
+      ref.width,
+      ref.height,
+      ref.file_size,
+      ref.id,
+      ref.created_at,
+    ]
+  );
+  const assetId = inserted.rows[0].id;
+
+  // Pair an `uploads` row so contentType + originalFilename live where the
+  // existing upload code path expects them (the references table didn't
+  // have a sibling table; uploads.assetId is unique-constrained).
+  // ON CONFLICT DO NOTHING covers the rare race where someone re-runs a
+  // partially-applied migration.
+  await client.query(
+    `INSERT INTO "uploads" (asset_id, uploader_id, original_filename, content_type, created_at)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (asset_id) DO NOTHING`,
+    [
+      assetId,
+      ref.user_id,
+      ref.file_name ?? "reference",
+      ref.mime_type,
+      ref.created_at,
+    ]
+  );
+
+  return { assetId, alreadyMigrated: false };
+}
+
+/**
+ * Retarget brand anchors for one user. Idempotent: if every anchor ID in a
+ * brand already resolves to an existing asset, the brand is left alone.
+ *
+ * Returns counts so the verifier can report what changed.
+ */
+async function retargetBrandAnchors(
+  client: PoolClient,
+  userId: string,
+  legacyMap: Map<string, string>,
+  report: VerifierReport
+) {
+  // Find every brand that the user has a membership on (so we don't touch
+  // brands that belong to a different workspace/user). The user is a
+  // creator/manager via brand_members.
+  const brandRows = await client.query<BrandRow>(
+    `SELECT b.id, b.workspace_id, b.anchor_asset_ids
+       FROM "brands" b
+      WHERE EXISTS (
+              SELECT 1 FROM "brand_members" bm
+               WHERE bm.brand_id = b.id AND bm.user_id = $1
+            )
+        AND jsonb_array_length(COALESCE(b.anchor_asset_ids, '[]'::jsonb)) > 0`,
+    [userId]
+  );
+
+  for (const brand of brandRows.rows) {
+    const oldAnchors: string[] = brand.anchor_asset_ids ?? [];
+    if (oldAnchors.length === 0) continue;
+
+    const newAnchors: string[] = [];
+    const unmapped: string[] = [];
+
+    for (const oldId of oldAnchors) {
+      // Path A: this id is a legacy reference id this user owns — remap.
+      const mapped = legacyMap.get(oldId);
+      if (mapped) {
+        newAnchors.push(mapped);
+        continue;
+      }
+
+      // Path B: already retargeted (asset id) — leave it. Verify it exists
+      // so we don't propagate a stale id.
+      const { rowCount } = await client.query(
+        `SELECT 1 FROM "assets" WHERE id = $1`,
+        [oldId]
+      );
+      if (rowCount && rowCount > 0) {
+        newAnchors.push(oldId);
+        continue;
+      }
+
+      // Path C: dangling pointer — neither a known reference for this user
+      // nor a live asset. Report and refuse to write.
+      unmapped.push(oldId);
+    }
+
+    if (unmapped.length > 0) {
+      report.unmappedAnchorIds.push(...unmapped);
+      report.errors.push({
+        userId,
+        brandId: brand.id,
+        message: `Refusing to retarget brand ${brand.id}: ${unmapped.length} anchor id(s) failed to resolve`,
+      });
+      continue; // skip the write — caller's transaction stays clean for next brand
+    }
+
+    // Idempotency: if the array is unchanged (already retargeted), don't write.
+    if (
+      newAnchors.length === oldAnchors.length &&
+      newAnchors.every((id, i) => id === oldAnchors[i])
+    ) {
+      continue;
+    }
+
+    await client.query(
+      `UPDATE "brands" SET anchor_asset_ids = $1::jsonb WHERE id = $2`,
+      [JSON.stringify(newAnchors), brand.id]
+    );
+    report.brandsUpdated += 1;
+    // Count only the entries that actually changed pointer (i.e. were
+    // legacy reference ids on the way in).
+    for (let i = 0; i < oldAnchors.length; i += 1) {
+      if (legacyMap.has(oldAnchors[i])) report.anchorIdsRetargeted += 1;
+    }
+  }
+}
+
+async function processUser(
+  pool: Pool,
+  userId: string,
+  report: VerifierReport
+) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const refs = await fetchReferencesForUser(client, userId);
+    report.referencesIn += refs.length;
+
+    const legacyMap = await existingLegacyMap(client, userId);
+
+    // assets.brand_id is NOT NULL post-0010. References with brand_id = NULL
+    // fold into the user's Personal brand (mirrors the 0009 fold-in for
+    // legacy generated assets).
+    const personalBrandId = await resolvePersonalBrandId(client, userId);
+    const needsPersonal = refs.some((r) => r.brand_id === null);
+    if (needsPersonal && !personalBrandId) {
+      throw new Error(
+        `User ${userId} has null-brand references but no Personal brand — ` +
+          `0009 backfill should have created one. Refusing to drop data.`
+      );
+    }
+
+    for (const ref of refs) {
+      const effectiveBrandId = ref.brand_id ?? personalBrandId!;
+      const { assetId, alreadyMigrated } = await insertReferenceAsAsset(
+        client,
+        { ...ref, brand_id: effectiveBrandId }
+      );
+      legacyMap.set(ref.id, assetId);
+      if (alreadyMigrated) {
+        report.assetsAlreadyMigrated += 1;
+      } else {
+        report.assetsInsertedThisRun += 1;
+      }
+    }
+
+    await retargetBrandAnchors(client, userId, legacyMap, report);
+
+    await client.query("COMMIT");
+    report.usersProcessed += 1;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    const message = err instanceof Error ? err.message : String(err);
+    report.errors.push({ userId, message });
+  } finally {
+    client.release();
+  }
+}
+
+export async function runMigration(
+  pool: Pool
+): Promise<VerifierReport> {
+  const report = emptyReport();
+  const userIds = await listUsersWithReferences(pool);
+
+  for (const userId of userIds) {
+    await processUser(pool, userId, report);
+  }
+
+  // Final orphan-anchor sweep: any brand whose anchor_asset_ids contains an
+  // id that is NOT a known asset id is reported as a mismatched user scope.
+  // (This catches the edge case where a brand is anchored to references
+  // owned by a user who *isn't* a member of the brand — those are not
+  // touched by per-user processing above.)
+  const { rows: orphanRows } = await pool.query<{
+    id: string;
+    bad: string[];
+  }>(
+    `SELECT b.id,
+            ARRAY(
+              SELECT jsonb_array_elements_text(b.anchor_asset_ids)
+              EXCEPT
+              SELECT id::text FROM "assets"
+            ) AS bad
+       FROM "brands" b
+      WHERE jsonb_array_length(COALESCE(b.anchor_asset_ids, '[]'::jsonb)) > 0`
+  );
+  for (const row of orphanRows) {
+    if (row.bad.length === 0) continue;
+    // Are any of these still references (i.e. owned by a user we never
+    // processed)? If so, they're mismatched scopes.
+    const stillRefs = await pool.query<{ id: string }>(
+      `SELECT id FROM "references" WHERE id::text = ANY($1)`,
+      [row.bad]
+    );
+    for (const r of stillRefs.rows) {
+      report.mismatchedUserScopes.push(`brand=${row.id} ref=${r.id}`);
+    }
+  }
+
+  return report;
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL required");
+    process.exit(2);
+  }
+  const pool = new Pool({ connectionString: url });
+  try {
+    const report = await runMigration(pool);
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+    if (report.errors.length > 0) process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run main() when invoked as a CLI; tests import runMigration directly.
+const isCli = (() => {
+  // tsx doesn't always set require.main, so check argv[1].
+  if (typeof process === "undefined") return false;
+  const entry = process.argv[1] ?? "";
+  return entry.endsWith("migrate-references-to-assets.ts") ||
+    entry.endsWith("migrate-references-to-assets.js") ||
+    entry.endsWith("migrate-references-to-assets");
+})();
+
+if (isCli) {
+  main().catch((err) => {
+    console.error("migrate-references-to-assets crashed:", err);
+    process.exit(2);
+  });
+}

--- a/src/app/(dashboard)/generate/generate-client.tsx
+++ b/src/app/(dashboard)/generate/generate-client.tsx
@@ -393,14 +393,18 @@ export function GenerateClient({
   const [refPickerLoading, setRefPickerLoading] = useState(false);
   const [refPickerCursor, setRefPickerCursor] = useState<string | null>(null);
 
+  // T022 — picker reads from /api/library directly. The library item shape is
+  // a superset of the legacy references shape (per T011's contract), so the
+  // picker's narrow projection ({ id, url, thumbnailUrl, fileName }) keeps
+  // working unchanged. Cursor is opaque on the client.
   function handleRefPickerOpen() {
     setShowRefPicker(true);
     if (refPickerItems.length === 0) {
       setRefPickerLoading(true);
-      fetch("/api/references?limit=20")
+      fetch("/api/library?limit=20")
         .then((r) => (r.ok ? r.json() : Promise.reject()))
-        .then((data: { references: typeof refPickerItems; nextCursor: string | null }) => {
-          setRefPickerItems(data.references);
+        .then((data: { items: typeof refPickerItems; nextCursor: string | null }) => {
+          setRefPickerItems(data.items);
           setRefPickerCursor(data.nextCursor);
         })
         .catch(() => {})
@@ -411,10 +415,10 @@ export function GenerateClient({
   function handleRefPickerLoadMore() {
     if (!refPickerCursor || refPickerLoading) return;
     setRefPickerLoading(true);
-    fetch(`/api/references?limit=20&cursor=${refPickerCursor}`)
+    fetch(`/api/library?limit=20&cursor=${encodeURIComponent(refPickerCursor)}`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
-      .then((data: { references: typeof refPickerItems; nextCursor: string | null }) => {
-        setRefPickerItems((prev) => [...prev, ...data.references]);
+      .then((data: { items: typeof refPickerItems; nextCursor: string | null }) => {
+        setRefPickerItems((prev) => [...prev, ...data.items]);
         setRefPickerCursor(data.nextCursor);
       })
       .catch(() => {})

--- a/src/app/(dashboard)/library/detail-panel.tsx
+++ b/src/app/(dashboard)/library/detail-panel.tsx
@@ -1,0 +1,661 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Download,
+  Hash,
+  Loader2,
+  Pin,
+  Sparkles,
+  Trash2,
+  Wand2,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import type { LibraryAsset } from "./library-client";
+
+export interface LibraryBrand {
+  id: string;
+  name: string;
+  color: string;
+  isPersonal: boolean;
+  anchorAssetIds: string[];
+}
+
+interface LibraryDetailPanelProps {
+  asset: LibraryAsset | null;
+  brands: LibraryBrand[];
+  onClose: () => void;
+  onAssetUpdate: (next: LibraryAsset) => void;
+  onAssetDelete: (id: string) => void;
+  onBrandPinChange: (
+    brandId: string,
+    assetId: string,
+    pinned: boolean
+  ) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Detail panel — slide-out Sheet.
+// Composition: header (file-name editor) + scrollable body (preview, metadata,
+// tags, campaigns, brand-pin list) + footer (Use as input / Download / Delete).
+// Open state is derived from `asset !== null` so consumers don't pass a
+// boolean alongside the data — see vercel-composition-patterns.
+// ---------------------------------------------------------------------------
+
+export function LibraryDetailPanel({
+  asset,
+  brands,
+  onClose,
+  onAssetUpdate,
+  onAssetDelete,
+  onBrandPinChange,
+}: LibraryDetailPanelProps) {
+  return (
+    <Sheet
+      open={asset !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-full gap-0 overflow-y-auto sm:!max-w-md"
+      >
+        {asset ? (
+          <DetailPanelBody
+            asset={asset}
+            brands={brands}
+            onAssetUpdate={onAssetUpdate}
+            onAssetDelete={onAssetDelete}
+            onBrandPinChange={onBrandPinChange}
+          />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Body — split out so the Sheet doesn't hold stale state on close/reopen.
+// `key={asset.id}` on the parent isn't necessary: each open re-mounts the
+// body via the conditional render above, which is the same effect.
+// ---------------------------------------------------------------------------
+
+function DetailPanelBody({
+  asset,
+  brands,
+  onAssetUpdate,
+  onAssetDelete,
+  onBrandPinChange,
+}: {
+  asset: LibraryAsset;
+  brands: LibraryBrand[];
+  onAssetUpdate: (next: LibraryAsset) => void;
+  onAssetDelete: (id: string) => void;
+  onBrandPinChange: (
+    brandId: string,
+    assetId: string,
+    pinned: boolean
+  ) => void;
+}) {
+  const router = useRouter();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleUse = () => {
+    const params = new URLSearchParams({ imageInput: asset.url });
+    router.push(`/generate?${params.toString()}`);
+  };
+
+  const handleDownload = () => {
+    const a = document.createElement("a");
+    a.href = asset.url;
+    a.download = asset.fileName ?? `library-${asset.id.slice(0, 8)}.png`;
+    a.click();
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/library/${asset.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      toast.success("Asset deleted");
+      onAssetDelete(asset.id);
+      setConfirmDelete(false);
+    } catch {
+      toast.error("Couldn't delete asset. Try again.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <SheetHeader className="px-5 pt-5 pb-3">
+        <SheetTitle className="truncate pr-8">
+          {asset.fileName ?? "Untitled asset"}
+        </SheetTitle>
+        <SheetDescription>
+          {formatRelativeDate(asset.createdAt)} · {humanSource(asset.source)}
+        </SheetDescription>
+      </SheetHeader>
+
+      <Separator />
+
+      <div className="flex flex-col gap-5 px-5 py-5">
+        {/* Preview */}
+        <div className="overflow-hidden rounded-xl bg-muted ring-1 ring-foreground/10">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={asset.url}
+            alt={asset.fileName ?? "Library asset preview"}
+            className="block h-auto max-h-[55vh] w-full object-contain"
+            loading="eager"
+            decoding="async"
+          />
+        </div>
+
+        {/* Metadata chips */}
+        <MetadataChips asset={asset} />
+
+        <Separator />
+
+        {/* File name */}
+        <FileNameField
+          key={asset.id}
+          assetId={asset.id}
+          initialValue={asset.fileName ?? ""}
+          onSaved={(fileName) => onAssetUpdate({ ...asset, fileName })}
+        />
+
+        {/* Tags */}
+        <ChipEditor
+          label="Tags"
+          placeholder="Add a tag"
+          values={asset.tags}
+          onChange={async (next) => {
+            const ok = await patchAsset(asset.id, { tags: next });
+            if (ok) onAssetUpdate({ ...asset, tags: next });
+            return ok;
+          }}
+          emptyHint="Tags help you find this asset later — add a few descriptors."
+        />
+
+        {/* Campaigns */}
+        <ChipEditor
+          label="Campaigns"
+          placeholder="Add a campaign"
+          values={asset.campaigns}
+          onChange={async (next) => {
+            const ok = await patchAsset(asset.id, { campaigns: next });
+            if (ok) onAssetUpdate({ ...asset, campaigns: next });
+            return ok;
+          }}
+          emptyHint="Group assets by campaign to keep launches organized."
+        />
+
+        <Separator />
+
+        {/* Brand-anchor pinning */}
+        <BrandPinList
+          assetId={asset.id}
+          brands={brands}
+          onChange={onBrandPinChange}
+        />
+      </div>
+
+      <SheetFooter className="sticky bottom-0 border-t border-border bg-background/95 px-5 py-4 backdrop-blur supports-backdrop-filter:bg-background/80">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button onClick={handleUse} className="flex-1 min-w-[10rem]">
+            <Wand2 aria-hidden />
+            Use as input
+          </Button>
+          <Button variant="outline" onClick={handleDownload} size="icon">
+            <Download aria-hidden />
+            <span className="sr-only">Download</span>
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => setConfirmDelete(true)}
+            size="icon"
+          >
+            <Trash2 aria-hidden />
+            <span className="sr-only">Delete</span>
+          </Button>
+        </div>
+      </SheetFooter>
+
+      <Dialog
+        open={confirmDelete}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDelete(false);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete asset?</DialogTitle>
+            <DialogDescription>
+              This permanently removes the asset and its thumbnail from
+              storage. Brews and history that referenced it will keep their
+              copies.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setConfirmDelete(false)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? (
+                <>
+                  <Loader2 className="animate-spin" aria-hidden />
+                  Deleting…
+                </>
+              ) : (
+                <>
+                  <Trash2 aria-hidden />
+                  Delete
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Metadata chips
+// ---------------------------------------------------------------------------
+
+function MetadataChips({ asset }: { asset: LibraryAsset }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {asset.width && asset.height ? (
+        <Badge variant="secondary">
+          {asset.width}×{asset.height}
+        </Badge>
+      ) : null}
+      {asset.fileSize ? (
+        <Badge variant="secondary">{formatFileSize(asset.fileSize)}</Badge>
+      ) : null}
+      {asset.usageCount > 0 ? (
+        <Badge variant="outline">
+          <Hash aria-hidden />
+          Used {asset.usageCount} {asset.usageCount === 1 ? "time" : "times"}
+        </Badge>
+      ) : null}
+      {asset.embeddedAt ? (
+        <Badge variant="outline" className="gap-1">
+          <Sparkles aria-hidden />
+          Indexed
+        </Badge>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// File name editor — saves on blur (matches the spec's "editable for v1" call).
+// ---------------------------------------------------------------------------
+
+function FileNameField({
+  assetId,
+  initialValue,
+  onSaved,
+}: {
+  assetId: string;
+  initialValue: string;
+  onSaved: (next: string | null) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const [saving, setSaving] = useState(false);
+
+  // Note: parent passes `key={assetId}` so a different asset re-mounts this
+  // component, which means we don't need a sync effect to reset `value`.
+
+  const persist = async () => {
+    const trimmed = value.trim();
+    if (trimmed === initialValue.trim()) return;
+    setSaving(true);
+    try {
+      const next = trimmed.length > 0 ? trimmed : null;
+      const ok = await patchAsset(assetId, { fileName: next });
+      if (ok) {
+        onSaved(next);
+        toast.success("Name updated");
+      } else {
+        toast.error("Couldn't rename. Try again.");
+        setValue(initialValue);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={`filename-${assetId}`}>File name</Label>
+      <div className="relative">
+        <Input
+          id={`filename-${assetId}`}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={persist}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          placeholder="Untitled asset"
+          disabled={saving}
+        />
+        {saving && (
+          <Loader2
+            className="absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-muted-foreground"
+            aria-hidden
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chip editor — generic over tags + campaigns. Patterns-explicit-variants:
+// no boolean `mode="campaign"` prop; both call sites just pass label + onChange.
+// ---------------------------------------------------------------------------
+
+function ChipEditor({
+  label,
+  placeholder,
+  values,
+  onChange,
+  emptyHint,
+}: {
+  label: string;
+  placeholder: string;
+  values: string[];
+  onChange: (next: string[]) => Promise<boolean>;
+  emptyHint: string;
+}) {
+  const [draft, setDraft] = useState("");
+  const [pending, setPending] = useState<string | null>(null);
+
+  const commitAdd = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    if (values.includes(trimmed)) {
+      setDraft("");
+      return;
+    }
+    const next = [...values, trimmed];
+    setPending(trimmed);
+    const ok = await onChange(next);
+    setPending(null);
+    if (!ok) {
+      toast.error(`Couldn't add ${label.toLowerCase().replace(/s$/, "")}.`);
+      return;
+    }
+    setDraft("");
+  };
+
+  const handleRemove = async (val: string) => {
+    setPending(val);
+    const next = values.filter((v) => v !== val);
+    const ok = await onChange(next);
+    setPending(null);
+    if (!ok) {
+      toast.error(`Couldn't remove ${label.toLowerCase().replace(/s$/, "")}.`);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>{label}</Label>
+      {values.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => handleRemove(v)}
+              disabled={pending === v}
+              className={cn(
+                "group/chip inline-flex h-6 items-center gap-1 rounded-md bg-muted px-2 text-xs font-medium text-foreground ring-1 ring-foreground/10 transition-colors",
+                "hover:bg-destructive/10 hover:text-destructive hover:ring-destructive/30",
+                "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                pending === v && "opacity-60"
+              )}
+              aria-label={`Remove ${label.toLowerCase().replace(/s$/, "")} ${v}`}
+            >
+              <span>{v}</span>
+              {pending === v ? (
+                <Loader2 className="size-3 animate-spin" aria-hidden />
+              ) : (
+                <X
+                  className="size-3 text-muted-foreground transition-colors group-hover/chip:text-destructive"
+                  aria-hidden
+                />
+              )}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">{emptyHint}</p>
+      )}
+      <div className="flex items-center gap-2">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitAdd();
+            }
+            if (e.key === "Backspace" && !draft && values.length > 0) {
+              handleRemove(values[values.length - 1]);
+            }
+          }}
+          placeholder={placeholder}
+          aria-label={`Add ${label.toLowerCase().replace(/s$/, "")}`}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={commitAdd}
+          disabled={!draft.trim() || pending !== null}
+        >
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Brand-anchor pin list
+// ---------------------------------------------------------------------------
+
+function BrandPinList({
+  assetId,
+  brands,
+  onChange,
+}: {
+  assetId: string;
+  brands: LibraryBrand[];
+  onChange: (brandId: string, assetId: string, pinned: boolean) => void;
+}) {
+  const [busy, setBusy] = useState<string | null>(null);
+
+  if (brands.length === 0) {
+    return null;
+  }
+
+  const togglePin = async (brand: LibraryBrand) => {
+    const isPinned = brand.anchorAssetIds.includes(assetId);
+    setBusy(brand.id);
+    try {
+      const res = await fetch(`/api/library/${assetId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pinnedToBrand: { brandId: brand.id, pinned: !isPinned },
+        }),
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      onChange(brand.id, assetId, !isPinned);
+      toast.success(
+        !isPinned
+          ? `Pinned to ${brand.name}`
+          : `Unpinned from ${brand.name}`
+      );
+    } catch {
+      toast.error("Couldn't update brand pin. Try again.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>Pin to brand</Label>
+      <p className="text-xs text-muted-foreground">
+        Pinned assets show up as anchors on a brand&apos;s kit and influence
+        future generations.
+      </p>
+      <ul className="flex flex-col gap-1">
+        {brands.map((brand) => {
+          const pinned = brand.anchorAssetIds.includes(assetId);
+          const isBusy = busy === brand.id;
+          return (
+            <li key={brand.id}>
+              <button
+                type="button"
+                onClick={() => togglePin(brand)}
+                disabled={isBusy}
+                aria-pressed={pinned}
+                className={cn(
+                  "group/brand flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors",
+                  "hover:bg-accent",
+                  "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  pinned
+                    ? "bg-primary/10 text-primary ring-1 ring-primary/30"
+                    : "ring-1 ring-transparent",
+                  isBusy && "opacity-60"
+                )}
+              >
+                <span
+                  aria-hidden
+                  className="inline-block size-2.5 rounded-full ring-1 ring-foreground/20"
+                  style={{ background: brand.color }}
+                />
+                <span className="flex-1 truncate">
+                  {brand.isPersonal ? `${brand.name} (Personal)` : brand.name}
+                </span>
+                {isBusy ? (
+                  <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                ) : (
+                  <Pin
+                    className={cn(
+                      "size-4 shrink-0 transition-colors",
+                      pinned
+                        ? "text-primary"
+                        : "text-muted-foreground group-hover/brand:text-foreground"
+                    )}
+                    fill={pinned ? "currentColor" : "none"}
+                    aria-hidden
+                  />
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function patchAsset(
+  id: string,
+  body: Record<string, unknown>
+): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/library/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function humanSource(source: LibraryAsset["source"]): string {
+  switch (source) {
+    case "uploaded":
+      return "uploaded";
+    case "generated":
+      return "generated";
+    case "imported":
+      return "imported";
+    default:
+      return source;
+  }
+}
+
+function formatRelativeDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/app/(dashboard)/library/filter-bar.tsx
+++ b/src/app/(dashboard)/library/filter-bar.tsx
@@ -1,0 +1,1051 @@
+"use client";
+
+/**
+ * FilterBar — sticky toolbar above the Library grid with primary facets
+ * (Brand, Campaign, Tag) visible by default and Source/Status hidden behind
+ * a "More" hatch. Mobile collapses to [Search] [Filters · N] with a bottom
+ * sheet for staged filter editing.
+ *
+ * Composition (compound components — no boolean prop sprawl):
+ *
+ *   <FilterBar>
+ *     <FilterBar.Search>
+ *       <SearchInput.Field />
+ *       <SearchInput.ModeToggle />        // null in Phase 4
+ *     </FilterBar.Search>
+ *     <FilterBar.Facets>
+ *       <BrandFacet brands={brands} />
+ *       <CampaignFacet campaigns={campaigns} />
+ *       <TagFacet tags={tags} />
+ *       <FilterBar.More>
+ *         <SourceFacet />
+ *         <StatusFacet visible={hasMixedStatuses} />
+ *       </FilterBar.More>
+ *     </FilterBar.Facets>
+ *     <FilterBar.Summary />
+ *     <FilterBar.MobileSheet ... />
+ *   </FilterBar>
+ *
+ * Every facet reads/writes via useLibraryQuery — no prop drilling.
+ */
+
+import { useState } from "react";
+import {
+  Building2,
+  Megaphone,
+  Tag as TagIcon,
+  SlidersHorizontal,
+  Sparkles,
+  Upload,
+  ImageDown,
+  CheckCircle2,
+  Hourglass,
+  XCircle,
+  Archive,
+  FileText,
+  Filter,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import {
+  type AssetSource,
+  type AssetStatus,
+  type LibraryQuery,
+  type TagOp,
+  EMPTY_LIBRARY_QUERY,
+  countActive,
+  serializeLibraryQuery,
+  useLibraryQuery,
+} from "./use-library-query";
+
+// ---------------------------------------------------------------------------
+// Public option types — the page server-hydrates these so popovers don't
+// round-trip on first open.
+// ---------------------------------------------------------------------------
+
+export interface BrandOption {
+  id: string;
+  name: string;
+}
+
+export interface CampaignOption {
+  id: string;
+  name: string;
+  brandId: string;
+}
+
+export interface TagOption {
+  /** Stable identifier for the URL — equals the tag string today. */
+  id: string;
+  /** Display label. */
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Root + slots
+// ---------------------------------------------------------------------------
+
+interface FilterBarProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FilterBar({ children, className }: FilterBarProps) {
+  return (
+    <div
+      data-slot="library-filter-bar"
+      className={cn(
+        // Sticky chrome surface — backdrop blur once stuck. Non-card → rounded-none.
+        "sticky top-0 z-30 -mx-6 border-b border-border bg-background/85 px-6 py-3 backdrop-blur",
+        // The page sets `space-y-6` on its container; counter that for the bar
+        // by pulling it tight against the header.
+        "supports-backdrop-filter:bg-background/70",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Search({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      data-slot="library-filter-search"
+      className="flex min-w-0 flex-1 items-center"
+    >
+      {children}
+    </div>
+  );
+}
+
+function Facets({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      data-slot="library-filter-facets"
+      className="hidden items-center gap-1.5 md:flex"
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger button shared across every facet. Active state changes both color
+// AND label so we don't rely on color alone (WCAG 1.4.1).
+// ---------------------------------------------------------------------------
+
+interface FacetTriggerProps extends React.ComponentProps<typeof Button> {
+  active: boolean;
+  icon: React.ReactNode;
+  label: string;
+  ariaLabel?: string;
+}
+
+function FacetTrigger({
+  active,
+  icon,
+  label,
+  ariaLabel,
+  className,
+  ...props
+}: FacetTriggerProps) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      aria-label={ariaLabel ?? label}
+      className={cn(
+        "gap-1.5 ring-1 ring-foreground/15",
+        active &&
+          "border-transparent bg-primary/10 text-primary ring-primary/30 hover:bg-primary/15 hover:text-primary",
+        className
+      )}
+      {...props}
+    >
+      {icon}
+      {label}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BrandFacet — single-select for v1 (per brief; matches the URL contract).
+// ---------------------------------------------------------------------------
+
+export function BrandFacet({ brands }: { brands: BrandOption[] }) {
+  const { query, setQuery } = useLibraryQuery();
+  const active = !!query.brand;
+  const selected = brands.find((b) => b.id === query.brand);
+  const label = selected ? truncate(selected.name, 18) : "Brand";
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <FacetTrigger
+            active={active}
+            icon={<Building2 className="size-3.5" aria-hidden />}
+            label={label}
+            ariaLabel={
+              active
+                ? `Brand filter — ${selected?.name ?? "selected"}`
+                : "Brand filter"
+            }
+          />
+        }
+      />
+      <PopoverContent align="start" className="w-64 p-0">
+        <Command>
+          <CommandInput placeholder="Search brands…" />
+          <CommandList>
+            <CommandEmpty>No brands.</CommandEmpty>
+            <CommandGroup>
+              {brands.map((b) => {
+                const checked = query.brand === b.id;
+                return (
+                  <CommandItem
+                    key={b.id}
+                    value={b.name}
+                    data-checked={checked || undefined}
+                    onSelect={() =>
+                      setQuery({ brand: checked ? null : b.id })
+                    }
+                  >
+                    {b.name}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CampaignFacet — single-select for v1.
+// ---------------------------------------------------------------------------
+
+export function CampaignFacet({
+  campaigns,
+}: {
+  campaigns: CampaignOption[];
+}) {
+  const { query, setQuery } = useLibraryQuery();
+  const active = !!query.campaign;
+  const selected = campaigns.find((c) => c.id === query.campaign);
+  const label = selected ? truncate(selected.name, 18) : "Campaign";
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <FacetTrigger
+            active={active}
+            icon={<Megaphone className="size-3.5" aria-hidden />}
+            label={label}
+            ariaLabel={
+              active
+                ? `Campaign filter — ${selected?.name ?? "selected"}`
+                : "Campaign filter"
+            }
+          />
+        }
+      />
+      <PopoverContent align="start" className="w-64 p-0">
+        <Command>
+          <CommandInput placeholder="Search campaigns…" />
+          <CommandList>
+            <CommandEmpty>No campaigns.</CommandEmpty>
+            <CommandGroup>
+              {campaigns.map((c) => {
+                const checked = query.campaign === c.id;
+                return (
+                  <CommandItem
+                    key={c.id}
+                    value={c.name}
+                    data-checked={checked || undefined}
+                    onSelect={() =>
+                      setQuery({ campaign: checked ? null : c.id })
+                    }
+                  >
+                    {c.name}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TagFacet — multi-select with OR/AND switcher at the top of the body.
+// ---------------------------------------------------------------------------
+
+export function TagFacet({ tags }: { tags: TagOption[] }) {
+  const { query, setQuery, toggleTag } = useLibraryQuery();
+  const count = query.tags.length;
+  const active = count > 0;
+  const label =
+    count === 0
+      ? "Tag"
+      : count === 1
+      ? truncate(
+          tags.find((t) => t.id === query.tags[0])?.label ?? query.tags[0],
+          16
+        )
+      : `${count} tags`;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <FacetTrigger
+            active={active}
+            icon={<TagIcon className="size-3.5" aria-hidden />}
+            label={label}
+            ariaLabel={
+              active
+                ? `Tag filter — ${count} selected`
+                : "Tag filter"
+            }
+          />
+        }
+      />
+      <PopoverContent align="start" className="w-72 p-0">
+        <div className="flex items-center justify-between border-b border-border px-2.5 py-1.5 text-xs text-muted-foreground">
+          <span className="font-medium">Match</span>
+          <TagOpToggle
+            value={query.tagOp}
+            onChange={(tagOp) => setQuery({ tagOp })}
+            disabled={count < 2}
+          />
+        </div>
+        <Command>
+          <CommandInput placeholder="Search tags…" />
+          <CommandList>
+            <CommandEmpty>No tags.</CommandEmpty>
+            <CommandGroup>
+              {tags.map((t) => {
+                const checked = query.tags.includes(t.id);
+                return (
+                  <CommandItem
+                    key={t.id}
+                    value={t.label}
+                    data-checked={checked || undefined}
+                    onSelect={() => toggleTag(t.id)}
+                  >
+                    {t.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function TagOpToggle({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: TagOp;
+  onChange: (next: TagOp) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Tag match mode"
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5 text-[11px] font-medium",
+        disabled && "opacity-50"
+      )}
+    >
+      {(["or", "and"] as const).map((op) => {
+        const selected = value === op;
+        return (
+          <button
+            key={op}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => onChange(op)}
+            className={cn(
+              "rounded-sm px-2 py-0.5 transition-colors",
+              selected
+                ? "bg-background text-foreground shadow-sm ring-1 ring-foreground/10"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {op === "or" ? "Any (OR)" : "All (AND)"}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// More — Source + Status sections inside one Popover.
+// ---------------------------------------------------------------------------
+
+interface MoreProps {
+  children: React.ReactNode;
+}
+
+function More({ children }: MoreProps) {
+  const { query } = useLibraryQuery();
+  const moreCount = query.sources.length + query.statuses.length;
+  const active = moreCount > 0;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={
+              active ? `More filters — ${moreCount} selected` : "More filters"
+            }
+            className={cn(
+              "gap-1.5",
+              active && "bg-primary/10 text-primary hover:bg-primary/15"
+            )}
+          >
+            <SlidersHorizontal className="size-3.5" aria-hidden />
+            More
+            {active && (
+              <span className="ml-0.5 rounded-full bg-primary/20 px-1.5 py-px text-[10px] font-semibold tabular-nums text-primary">
+                {moreCount}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      <PopoverContent align="end" className="w-72 p-3">
+        <div className="space-y-3">{children}</div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SourceFacet — checkbox list inside More. Empty selection = no filter.
+// ---------------------------------------------------------------------------
+
+const SOURCES: { value: AssetSource; label: string; icon: React.ReactNode }[] = [
+  {
+    value: "uploaded",
+    label: "Uploaded",
+    icon: <Upload className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "generated",
+    label: "Generated",
+    icon: <Sparkles className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "imported",
+    label: "Imported",
+    icon: <ImageDown className="size-3.5" aria-hidden />,
+  },
+];
+
+export function SourceFacet() {
+  const { query, setQuery } = useLibraryQuery();
+  return (
+    <FilterSection title="Source">
+      {SOURCES.map((s) => (
+        <CheckboxRow
+          key={s.value}
+          label={s.label}
+          icon={s.icon}
+          checked={query.sources.includes(s.value)}
+          onChange={(checked) => {
+            const next = checked
+              ? Array.from(new Set([...query.sources, s.value]))
+              : query.sources.filter((v) => v !== s.value);
+            setQuery({ sources: next });
+          }}
+        />
+      ))}
+    </FilterSection>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatusFacet — only renders when the user has multiple distinct statuses.
+// `visible` is an explicit prop (not a boolean knob *on* the facet, but a
+// composition gate so the parent can short-circuit cleanly).
+// ---------------------------------------------------------------------------
+
+const STATUSES: {
+  value: AssetStatus;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    value: "draft",
+    label: "Draft",
+    icon: <FileText className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "in_review",
+    label: "In review",
+    icon: <Hourglass className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "approved",
+    label: "Approved",
+    icon: <CheckCircle2 className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "rejected",
+    label: "Rejected",
+    icon: <XCircle className="size-3.5" aria-hidden />,
+  },
+  {
+    value: "archived",
+    label: "Archived",
+    icon: <Archive className="size-3.5" aria-hidden />,
+  },
+];
+
+export function StatusFacet({ visible = true }: { visible?: boolean }) {
+  const { query, setQuery } = useLibraryQuery();
+  if (!visible) return null;
+  return (
+    <FilterSection title="Status">
+      {STATUSES.map((s) => (
+        <CheckboxRow
+          key={s.value}
+          label={s.label}
+          icon={s.icon}
+          checked={query.statuses.includes(s.value)}
+          onChange={(checked) => {
+            const next = checked
+              ? Array.from(new Set([...query.statuses, s.value]))
+              : query.statuses.filter((v) => v !== s.value);
+            setQuery({ statuses: next });
+          }}
+        />
+      ))}
+    </FilterSection>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section + checkbox row primitives (local — not promoted to design system).
+// ---------------------------------------------------------------------------
+
+function FilterSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="px-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      <div className="space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+function CheckboxRow({
+  label,
+  icon,
+  checked,
+  onChange,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "group/row flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm",
+        "hover:bg-muted hover:text-foreground",
+        checked && "bg-primary/10 text-primary hover:bg-primary/15",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-4 items-center justify-center rounded-sm border",
+          checked
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-foreground/25"
+        )}
+      >
+        {checked && (
+          // Small inline check mark — avoid pulling in another Lucide icon.
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="size-3"
+          >
+            <path d="M3 8l3 3 7-7" />
+          </svg>
+        )}
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          "text-muted-foreground group-hover/row:text-foreground",
+          checked && "text-primary"
+        )}
+      >
+        {icon}
+      </span>
+      <span className="flex-1 truncate text-left">{label}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary — renders only when filters are non-default. Hydrates names from
+// the option lists passed in (so `brand=<uuid>` reads as the brand's name).
+// ---------------------------------------------------------------------------
+
+function Summary({
+  brands,
+  campaigns,
+  tags,
+}: {
+  brands: BrandOption[];
+  campaigns: CampaignOption[];
+  tags: TagOption[];
+}) {
+  const { query, resultsCount, clearAll, activeCount } = useLibraryQuery();
+  if (activeCount === 0) return null;
+
+  const parts: string[] = [];
+  if (query.brand) {
+    const b = brands.find((x) => x.id === query.brand);
+    if (b) parts.push(b.name);
+  }
+  if (query.campaign) {
+    const c = campaigns.find((x) => x.id === query.campaign);
+    if (c) parts.push(c.name);
+  }
+  if (query.tags.length === 1) {
+    const t = tags.find((x) => x.id === query.tags[0]);
+    if (t) parts.push(t.label);
+  } else if (query.tags.length > 1) {
+    parts.push(`${query.tags.length} tags`);
+  }
+  if (query.sources.length === 1) {
+    parts.push(capitalize(query.sources[0]));
+  } else if (query.sources.length > 1) {
+    parts.push(`${query.sources.length} sources`);
+  }
+  if (query.statuses.length === 1) {
+    parts.push(humanStatus(query.statuses[0]));
+  } else if (query.statuses.length > 1) {
+    parts.push(`${query.statuses.length} statuses`);
+  }
+  if (query.q) parts.push(`“${query.q}”`);
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      <span className="truncate">
+        Filtering by{" "}
+        <span className="text-foreground">{parts.join(" · ")}</span>
+        {resultsCount !== null && (
+          <>
+            {" "}
+            <span className="text-muted-foreground/80">·</span>{" "}
+            <span className="tabular-nums text-foreground">
+              {formatCount(resultsCount)}
+            </span>
+          </>
+        )}
+      </span>
+      <Button
+        variant="link"
+        size="sm"
+        className="h-auto p-0 text-xs"
+        onClick={clearAll}
+        aria-label={`Clear ${activeCount} active filter${
+          activeCount === 1 ? "" : "s"
+        }`}
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MobileSheet — staged filter editing for narrow viewports.
+//
+// Desktop facets push to the URL immediately. Mobile sheet stages changes
+// locally and only commits on "Apply" — it's the only mode-difference
+// between the two, by design (large numbers of filter changes on a small
+// screen shouldn't each cause a navigation).
+// ---------------------------------------------------------------------------
+
+function MobileSheet({
+  brands,
+  campaigns,
+  tags,
+  hasMixedStatuses,
+}: {
+  brands: BrandOption[];
+  campaigns: CampaignOption[];
+  tags: TagOption[];
+  hasMixedStatuses: boolean;
+}) {
+  const { query, setQuery, clearAll, activeCount } = useLibraryQuery();
+  const [open, setOpen] = useState(false);
+  const [staged, setStaged] = useState<LibraryQuery>(query);
+  // Re-seed staged state on every open transition so partial edits from a
+  // previous open don't leak. Render-time sync (React 19) — no effect needed.
+  const [seededForOpen, setSeededForOpen] = useState(false);
+  if (open && !seededForOpen) {
+    setSeededForOpen(true);
+    setStaged(query);
+  } else if (!open && seededForOpen) {
+    setSeededForOpen(false);
+  }
+
+  const stagedCount = countActive(staged);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-label={
+              activeCount > 0
+                ? `Filters — ${activeCount} active`
+                : "Filters"
+            }
+            className={cn(
+              "gap-1.5 md:hidden",
+              activeCount > 0 &&
+                "border-transparent bg-primary/10 text-primary ring-1 ring-primary/30"
+            )}
+          >
+            <Filter className="size-3.5" aria-hidden />
+            Filters
+            {activeCount > 0 && (
+              <span className="rounded-full bg-primary/20 px-1.5 py-px text-[10px] font-semibold tabular-nums">
+                {activeCount}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      <SheetContent
+        side="bottom"
+        className="max-h-[85vh] overflow-y-auto md:hidden"
+      >
+        <SheetHeader>
+          <SheetTitle>Filter library</SheetTitle>
+        </SheetHeader>
+        <div className="space-y-5 px-4 pb-4">
+          <StagedSection title="Brand">
+            <StagedRadioList
+              options={brands.map((b) => ({ id: b.id, label: b.name }))}
+              value={staged.brand}
+              onChange={(v) => setStaged({ ...staged, brand: v })}
+            />
+          </StagedSection>
+          <StagedSection title="Campaign">
+            <StagedRadioList
+              options={campaigns.map((c) => ({ id: c.id, label: c.name }))}
+              value={staged.campaign}
+              onChange={(v) => setStaged({ ...staged, campaign: v })}
+            />
+          </StagedSection>
+          <StagedSection title="Tags">
+            <div className="flex items-center justify-between pb-1.5 text-xs text-muted-foreground">
+              <span className="font-medium">Match</span>
+              <TagOpToggle
+                value={staged.tagOp}
+                onChange={(tagOp) => setStaged({ ...staged, tagOp })}
+                disabled={staged.tags.length < 2}
+              />
+            </div>
+            <StagedCheckboxList
+              options={tags.map((t) => ({ id: t.id, label: t.label }))}
+              values={staged.tags}
+              onChange={(tags) => setStaged({ ...staged, tags })}
+            />
+          </StagedSection>
+          <StagedSection title="Source">
+            <StagedCheckboxList
+              options={SOURCES.map((s) => ({ id: s.value, label: s.label }))}
+              values={staged.sources}
+              onChange={(sources) =>
+                setStaged({
+                  ...staged,
+                  sources: sources as AssetSource[],
+                })
+              }
+            />
+          </StagedSection>
+          {hasMixedStatuses && (
+            <StagedSection title="Status">
+              <StagedCheckboxList
+                options={STATUSES.map((s) => ({
+                  id: s.value,
+                  label: s.label,
+                }))}
+                values={staged.statuses}
+                onChange={(statuses) =>
+                  setStaged({
+                    ...staged,
+                    statuses: statuses as AssetStatus[],
+                  })
+                }
+              />
+            </StagedSection>
+          )}
+        </div>
+        <SheetFooter className="sticky bottom-0 flex-row items-center justify-between gap-3 border-t border-border bg-background/95 px-4 py-3 backdrop-blur">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              setStaged(EMPTY_LIBRARY_QUERY);
+              clearAll();
+              setOpen(false);
+            }}
+          >
+            Reset
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              setQuery(staged);
+              setOpen(false);
+            }}
+          >
+            Apply
+            {stagedCount > 0 && (
+              <span className="ml-1 rounded-full bg-primary-foreground/20 px-1.5 py-px text-[10px] font-semibold tabular-nums">
+                {stagedCount}
+              </span>
+            )}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function StagedSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function StagedRadioList({
+  options,
+  value,
+  onChange,
+}: {
+  options: { id: string; label: string }[];
+  value: string | null;
+  onChange: (next: string | null) => void;
+}) {
+  return (
+    <div className="space-y-0.5">
+      {options.map((opt) => {
+        const checked = value === opt.id;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => onChange(checked ? null : opt.id)}
+            className={cn(
+              "flex w-full items-center justify-between rounded-md px-2 py-2 text-sm",
+              checked
+                ? "bg-primary/10 text-primary"
+                : "hover:bg-muted hover:text-foreground"
+            )}
+          >
+            <span className="truncate">{opt.label}</span>
+            {checked && (
+              <span className="text-[11px] font-medium">Selected</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StagedCheckboxList({
+  options,
+  values,
+  onChange,
+}: {
+  options: { id: string; label: string }[];
+  values: string[];
+  onChange: (next: string[]) => void;
+}) {
+  return (
+    <div className="space-y-0.5">
+      {options.map((opt) => {
+        const checked = values.includes(opt.id);
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            role="checkbox"
+            aria-checked={checked}
+            onClick={() => {
+              const next = checked
+                ? values.filter((v) => v !== opt.id)
+                : [...values, opt.id];
+              onChange(next);
+            }}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm",
+              checked
+                ? "bg-primary/10 text-primary"
+                : "hover:bg-muted hover:text-foreground"
+            )}
+          >
+            <span
+              aria-hidden
+              className={cn(
+                "flex size-4 items-center justify-center rounded-sm border",
+                checked
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-foreground/25"
+              )}
+            >
+              {checked && (
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="size-3"
+                >
+                  <path d="M3 8l3 3 7-7" />
+                </svg>
+              )}
+            </span>
+            <span className="flex-1 truncate text-left">{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, n - 1)}…`;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function humanStatus(s: AssetStatus): string {
+  switch (s) {
+    case "in_review":
+      return "In review";
+    default:
+      return capitalize(s);
+  }
+}
+
+function formatCount(n: number): string {
+  return `${n.toLocaleString()} result${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Helper: resolve a partial query → URL string. Useful for tests + the
+ * "Drop X filter" affordance once the API returns dropFilterCounts.
+ */
+export function buildLibraryUrl(query: Partial<LibraryQuery>): string {
+  const merged = { ...EMPTY_LIBRARY_QUERY, ...query };
+  const qs = serializeLibraryQuery(merged).toString();
+  return `/library${qs ? `?${qs}` : ""}`;
+}
+
+// ---------------------------------------------------------------------------
+// Compound API
+// ---------------------------------------------------------------------------
+
+FilterBar.Search = Search;
+FilterBar.Facets = Facets;
+FilterBar.More = More;
+FilterBar.Summary = Summary;
+FilterBar.MobileSheet = MobileSheet;

--- a/src/app/(dashboard)/library/filter-bar.tsx
+++ b/src/app/(dashboard)/library/filter-bar.tsx
@@ -47,6 +47,11 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -86,7 +91,15 @@ import {
 
 export interface BrandOption {
   id: string;
+  /** Display label. For personal brands the page server resolves this to the
+   *  owner's display name (falling back to their email local-part) so admins
+   *  can tell multiple "Personal" brands apart. */
   name: string;
+  /** True when this is a per-user personal brand. Drives avatar rendering
+   *  and the pinned-to-top sort. */
+  isPersonal?: boolean;
+  /** Owner avatar URL — only set for personal brands. */
+  ownerImage?: string | null;
 }
 
 export interface CampaignOption {
@@ -233,8 +246,19 @@ export function BrandFacet({ brands }: { brands: BrandOption[] }) {
                     onSelect={() =>
                       setQuery({ brand: checked ? null : b.id })
                     }
+                    className="gap-2"
                   >
-                    {b.name}
+                    {b.isPersonal ? (
+                      <Avatar size="sm" className="size-5">
+                        {b.ownerImage ? (
+                          <AvatarImage src={b.ownerImage} alt="" />
+                        ) : null}
+                        <AvatarFallback className="text-[10px]">
+                          {initialsFor(b.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                    ) : null}
+                    <span className="truncate">{b.name}</span>
                   </CommandItem>
                 );
               })}
@@ -1011,6 +1035,13 @@ function StagedCheckboxList({
 function truncate(s: string, n: number): string {
   if (s.length <= n) return s;
   return `${s.slice(0, n - 1)}…`;
+}
+
+function initialsFor(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
 function capitalize(s: string): string {

--- a/src/app/(dashboard)/library/library-client.tsx
+++ b/src/app/(dashboard)/library/library-client.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Hash, ImagePlus, Loader2, Sparkles, Wand2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { LibraryDetailPanel, type LibraryBrand } from "./detail-panel";
+
+// ---------------------------------------------------------------------------
+// Types — exported so page.tsx can produce the initial payload server-side.
+// ---------------------------------------------------------------------------
+
+export type AssetSource = "uploaded" | "generated" | "imported";
+
+export interface LibraryAsset {
+  id: string;
+  userId: string;
+  brandId: string | null;
+  source: AssetSource;
+  mediaType: "image" | "video";
+  url: string;
+  thumbnailUrl: string;
+  fileName: string | null;
+  fileSize: number | null;
+  width: number | null;
+  height: number | null;
+  usageCount: number;
+  embeddedAt: string | null;
+  createdAt: string;
+  tags: string[];
+  campaigns: string[];
+}
+
+interface LibraryClientProps {
+  initialItems: LibraryAsset[];
+  initialNextCursor: string | null;
+  initialBrands: LibraryBrand[];
+}
+
+// ---------------------------------------------------------------------------
+// Container — owns cursor state, fetches more pages, hosts the detail panel.
+// Composition: <LibraryClient> renders <LibraryGrid> + <LibraryDetailPanel>.
+// No boolean-prop sprawl: the panel's open state is derived from selection.
+// ---------------------------------------------------------------------------
+
+export function LibraryClient({
+  initialItems,
+  initialNextCursor,
+  initialBrands,
+}: LibraryClientProps) {
+  const [items, setItems] = useState<LibraryAsset[]>(initialItems);
+  const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [brands, setBrands] = useState<LibraryBrand[]>(initialBrands);
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(
+    async (cursor: string) => {
+      setLoadingMore(true);
+      try {
+        const params = new URLSearchParams({ limit: "30", cursor });
+        const res = await fetch(`/api/library?${params.toString()}`);
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const data = (await res.json()) as {
+          items: LibraryAsset[];
+          nextCursor: string | null;
+        };
+        setItems((prev) => [...prev, ...data.items]);
+        setNextCursor(data.nextCursor);
+      } catch {
+        toast.error("Couldn't load more assets. Try again.");
+      } finally {
+        setLoadingMore(false);
+      }
+    },
+    []
+  );
+
+  // Cursor-driven infinite scroll. IntersectionObserver beats a scroll-listener
+  // here — no rAF throttling needed, observer fires once per intersection.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    if (!nextCursor) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && nextCursor && !loadingMore) {
+          loadMore(nextCursor);
+        }
+      },
+      { rootMargin: "400px" }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [nextCursor, loadingMore, loadMore]);
+
+  // Keep `brands` fresh after a pin toggle — anchor lists live on brand rows.
+  const refreshBrands = useCallback(async () => {
+    try {
+      const res = await fetch("/api/brands");
+      if (!res.ok) return;
+      const rows = (await res.json()) as Array<{
+        id: string;
+        name: string;
+        color: string;
+        isPersonal: boolean;
+      }>;
+      // Keep our anchor map authoritative — brands API doesn't include
+      // anchorAssetIds on the list endpoint. We patch them in via a per-brand
+      // GET on first need, but for the toggle UI the previous list + the
+      // panel's local update is enough to stay in sync.
+      setBrands((prev) => {
+        const byId = new Map(prev.map((b) => [b.id, b]));
+        return rows.map((r) => ({
+          id: r.id,
+          name: r.name,
+          color: r.color,
+          isPersonal: r.isPersonal,
+          anchorAssetIds: byId.get(r.id)?.anchorAssetIds ?? [],
+        }));
+      });
+    } catch {
+      /* non-fatal */
+    }
+  }, []);
+
+  const handleAssetUpdate = useCallback(
+    (next: LibraryAsset) => {
+      setItems((prev) => prev.map((it) => (it.id === next.id ? next : it)));
+    },
+    []
+  );
+
+  const handleAssetDelete = useCallback((id: string) => {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+    setSelectedId((curr) => (curr === id ? null : curr));
+  }, []);
+
+  const handleBrandPinChange = useCallback(
+    (brandId: string, assetId: string, pinned: boolean) => {
+      setBrands((prev) =>
+        prev.map((b) => {
+          if (b.id !== brandId) return b;
+          const set = new Set(b.anchorAssetIds);
+          if (pinned) set.add(assetId);
+          else set.delete(assetId);
+          return { ...b, anchorAssetIds: Array.from(set) };
+        })
+      );
+      // Best-effort refresh in the background so we pick up server-side
+      // anchor-list invariants (e.g. dedupe, max-16 enforcement).
+      refreshBrands();
+    },
+    [refreshBrands]
+  );
+
+  const selected = selectedId
+    ? items.find((it) => it.id === selectedId) ?? null
+    : null;
+
+  if (items.length === 0) {
+    return <LibraryEmptyState />;
+  }
+
+  return (
+    <>
+      <LibraryGrid items={items} onSelect={setSelectedId} />
+
+      {/* Sentinel + spinner. Sentinel is always rendered when more pages exist
+          so the observer keeps a target after each successful page. */}
+      {nextCursor && <div ref={sentinelRef} className="h-4" aria-hidden />}
+      {loadingMore && (
+        <div
+          role="status"
+          aria-label="Loading more assets"
+          className="flex justify-center py-6"
+        >
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      <LibraryDetailPanel
+        asset={selected}
+        brands={brands}
+        onClose={() => setSelectedId(null)}
+        onAssetUpdate={handleAssetUpdate}
+        onAssetDelete={handleAssetDelete}
+        onBrandPinChange={handleBrandPinChange}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grid
+// ---------------------------------------------------------------------------
+
+function LibraryGrid({
+  items,
+  onSelect,
+}: {
+  items: LibraryAsset[];
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div
+      data-slot="library-grid"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+    >
+      {items.map((item) => (
+        <LibraryCard
+          key={item.id}
+          asset={item}
+          onClick={() => onSelect(item.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card — square thumbnail, source badge, hover overlay with metadata.
+// Mirrors references-client's visual treatment but adds a source badge and
+// wires through tags. Plain <img> matches the rest of the codebase (signed
+// R2 URLs aren't on the next.config remotePatterns allow-list).
+// ---------------------------------------------------------------------------
+
+function LibraryCard({
+  asset,
+  onClick,
+}: {
+  asset: LibraryAsset;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-slot="library-card"
+      className={cn(
+        "group/card relative overflow-hidden rounded-xl bg-muted text-left",
+        "ring-1 ring-foreground/10",
+        "hover:-translate-y-0.5 hover:shadow-lg hover:ring-primary/40",
+        "active:translate-y-px",
+        "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/60"
+      )}
+      aria-label={asset.fileName ?? `Asset ${asset.id.slice(0, 8)}`}
+    >
+      <div className="relative aspect-square">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={asset.thumbnailUrl}
+          alt={asset.fileName ?? "Library asset"}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          decoding="async"
+        />
+
+        {/* Source badge — top-left so it doesn't fight the usage count. */}
+        <div className="absolute left-2 top-2">
+          <SourceBadge source={asset.source} />
+        </div>
+
+        {/* Usage count — only when > 0; tabular-nums so the box doesn't jump. */}
+        {asset.usageCount > 0 && (
+          <div className="absolute right-2 top-2 inline-flex items-center gap-0.5 rounded-md bg-background/70 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-foreground backdrop-blur-sm">
+            <Hash className="size-2.5" aria-hidden />
+            {asset.usageCount}
+          </div>
+        )}
+
+        {/* Hover overlay — fades in metadata + dimensions chip. */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/75 via-black/20 to-transparent p-3 opacity-0 transition-opacity duration-150 group-hover/card:opacity-100 group-focus-visible/card:opacity-100">
+          {asset.fileName && (
+            <p className="line-clamp-1 text-xs font-medium text-white/95">
+              {asset.fileName}
+            </p>
+          )}
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            {asset.width && asset.height && (
+              <span className="rounded-sm bg-white/20 px-1.5 py-0.5 text-[10px] font-medium text-white/95 backdrop-blur-sm">
+                {asset.width}×{asset.height}
+              </span>
+            )}
+            {asset.tags.slice(0, 2).map((tag) => (
+              <span
+                key={tag}
+                className="rounded-sm bg-white/20 px-1.5 py-0.5 text-[10px] font-medium text-white/95 backdrop-blur-sm"
+              >
+                {tag}
+              </span>
+            ))}
+            {asset.tags.length > 2 && (
+              <span className="rounded-sm bg-white/20 px-1.5 py-0.5 text-[10px] font-medium text-white/95 backdrop-blur-sm">
+                +{asset.tags.length - 2}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Source badge — three explicit variants so we don't pile booleans on Badge.
+// Tinted, not filled — matches the destructive-style convention.
+// ---------------------------------------------------------------------------
+
+function SourceBadge({ source }: { source: AssetSource }) {
+  const label =
+    source === "uploaded"
+      ? "Upload"
+      : source === "generated"
+      ? "Generated"
+      : "Imported";
+
+  // Each source gets a single token-based tint. We avoid raw color literals;
+  // primary covers generated (the magical path), muted covers uploads,
+  // accent covers imports — all already first-class semantic tokens.
+  const variantClass =
+    source === "generated"
+      ? "bg-primary/15 text-primary ring-primary/25"
+      : source === "uploaded"
+      ? "bg-background/85 text-foreground ring-foreground/15"
+      : "bg-accent text-accent-foreground ring-foreground/15";
+
+  return (
+    <span
+      data-slot="source-badge"
+      className={cn(
+        "inline-flex h-5 items-center gap-1 rounded-md px-1.5 text-[10px] font-medium ring-1 backdrop-blur-sm",
+        variantClass
+      )}
+    >
+      {source === "generated" ? (
+        <Sparkles className="size-2.5" aria-hidden />
+      ) : null}
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state — short, encouraging, action-oriented per the voice guide.
+// ---------------------------------------------------------------------------
+
+function LibraryEmptyState() {
+  const router = useRouter();
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center rounded-2xl bg-card px-6 py-20 text-center ring-1 ring-foreground/10"
+    >
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+        <ImagePlus className="size-7" strokeWidth={1.5} aria-hidden />
+      </div>
+      <h3 className="font-heading text-lg font-semibold">
+        Nothing in your library yet
+      </h3>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        Upload an image or generate something — every asset you create lands
+        here, ready to tag, pin, and reuse.
+      </p>
+      <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+        <Button onClick={() => router.push("/generate")}>
+          <Wand2 aria-hidden />
+          Generate something
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            router.push("/generate?focus=imageInput")
+          }
+        >
+          <ImagePlus aria-hidden />
+          Upload a reference
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton (unused on first paint — page.tsx ships data — kept for the
+// dynamic import / CSR fallback the picker may eventually wire up.)
+// ---------------------------------------------------------------------------
+
+export function LibrarySkeletonGrid() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <Skeleton key={i} className="aspect-square rounded-xl" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/library/library-client.tsx
+++ b/src/app/(dashboard)/library/library-client.tsx
@@ -3,15 +3,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
+  Archive,
+  CheckCircle2,
+  FileText,
   Hash,
+  Hourglass,
   ImagePlus,
   Loader2,
   SearchX,
   Sparkles,
   Wand2,
+  XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { LibraryDetailPanel, type LibraryBrand } from "./detail-panel";
@@ -40,11 +55,26 @@ import {
 
 export type AssetSource = "uploaded" | "generated" | "imported";
 
+export type AssetStatus =
+  | "draft"
+  | "in_review"
+  | "approved"
+  | "rejected"
+  | "archived";
+
+export interface AssetCreator {
+  id: string;
+  name: string | null;
+  image: string | null;
+  email: string | null;
+}
+
 export interface LibraryAsset {
   id: string;
   userId: string;
   brandId: string | null;
   source: AssetSource;
+  status: AssetStatus;
   mediaType: "image" | "video";
   url: string;
   thumbnailUrl: string;
@@ -53,6 +83,7 @@ export interface LibraryAsset {
   width: number | null;
   height: number | null;
   usageCount: number;
+  creator: AssetCreator | null;
   embeddedAt: string | null;
   createdAt: string;
   tags: string[];
@@ -439,8 +470,9 @@ function LibraryCard({
           decoding="async"
         />
 
-        <div className="absolute left-2 top-2">
+        <div className="absolute left-2 top-2 flex items-center gap-1">
           <SourceBadge source={asset.source} />
+          <StatusBadge status={asset.status} />
         </div>
 
         {asset.usageCount > 0 && (
@@ -448,6 +480,14 @@ function LibraryCard({
             <Hash className="size-2.5" aria-hidden />
             {asset.usageCount}
           </div>
+        )}
+
+        {asset.creator && (
+          <CreatorAvatar
+            creator={asset.creator}
+            source={asset.source}
+            className="absolute bottom-2 right-2"
+          />
         )}
 
         <div className="pointer-events-none absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/75 via-black/20 to-transparent p-3 opacity-0 transition-opacity duration-150 group-hover/card:opacity-100 group-focus-visible/card:opacity-100">
@@ -514,6 +554,117 @@ function SourceBadge({ source }: { source: AssetSource }) {
       ) : null}
       {label}
     </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Status badge — five variants matching the asset workflow states.
+// Icons mirror the StatusFacet in filter-bar so users recognise the chips.
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: AssetStatus }) {
+  const config: Record<
+    AssetStatus,
+    { label: string; icon: React.ReactNode; className: string }
+  > = {
+    draft: {
+      label: "Draft",
+      icon: <FileText className="size-2.5" aria-hidden />,
+      className: "bg-background/85 text-muted-foreground ring-foreground/15",
+    },
+    in_review: {
+      label: "In review",
+      icon: <Hourglass className="size-2.5" aria-hidden />,
+      className: "bg-amber-500/15 text-amber-700 ring-amber-500/25 dark:text-amber-300",
+    },
+    approved: {
+      label: "Approved",
+      icon: <CheckCircle2 className="size-2.5" aria-hidden />,
+      className: "bg-emerald-500/15 text-emerald-700 ring-emerald-500/25 dark:text-emerald-300",
+    },
+    rejected: {
+      label: "Rejected",
+      icon: <XCircle className="size-2.5" aria-hidden />,
+      className: "bg-rose-500/15 text-rose-700 ring-rose-500/25 dark:text-rose-300",
+    },
+    archived: {
+      label: "Archived",
+      icon: <Archive className="size-2.5" aria-hidden />,
+      className: "bg-muted text-muted-foreground ring-foreground/15",
+    },
+  };
+  const { label, icon, className } = config[status];
+
+  return (
+    <span
+      data-slot="status-badge"
+      data-status={status}
+      className={cn(
+        "inline-flex h-5 items-center gap-1 rounded-md px-1.5 text-[10px] font-medium ring-1 backdrop-blur-sm",
+        className
+      )}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Creator avatar — bottom-right of the thumbnail. Tooltip surfaces the
+// member's display name (or email local-part fallback) plus the action verb
+// derived from `source` so admins can see who shipped what at a glance.
+// ---------------------------------------------------------------------------
+
+function CreatorAvatar({
+  creator,
+  source,
+  className,
+}: {
+  creator: AssetCreator;
+  source: AssetSource;
+  className?: string;
+}) {
+  const name = creator.name?.trim() || creator.email?.split("@")[0] || "Member";
+  const initials = (() => {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  })();
+  const verb =
+    source === "uploaded"
+      ? "uploaded"
+      : source === "imported"
+      ? "imported"
+      : "generated";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "inline-flex rounded-full ring-2 ring-background/80",
+              className
+            )}
+            aria-label={`${name} ${verb} this asset`}
+          >
+            <Avatar size="sm" className="size-6">
+              {creator.image ? (
+                <AvatarImage src={creator.image} alt="" />
+              ) : null}
+              <AvatarFallback className="text-[10px]">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+          </span>
+        }
+      />
+      <TooltipContent>
+        {name} {verb} this asset
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/app/(dashboard)/library/library-client.tsx
+++ b/src/app/(dashboard)/library/library-client.tsx
@@ -1,13 +1,38 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Hash, ImagePlus, Loader2, Sparkles, Wand2 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Hash,
+  ImagePlus,
+  Loader2,
+  SearchX,
+  Sparkles,
+  Wand2,
+} from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { LibraryDetailPanel, type LibraryBrand } from "./detail-panel";
+import {
+  FilterBar,
+  BrandFacet,
+  CampaignFacet,
+  TagFacet,
+  SourceFacet,
+  StatusFacet,
+  type BrandOption,
+  type CampaignOption,
+  type TagOption,
+} from "./filter-bar";
+import { SearchInput } from "./search-input";
+import {
+  serializeLibraryQuery,
+  useLibraryQuery,
+  parseLibraryQuery,
+  LibraryQueryProvider,
+} from "./use-library-query";
 
 // ---------------------------------------------------------------------------
 // Types — exported so page.tsx can produce the initial payload server-side.
@@ -37,56 +62,197 @@ export interface LibraryAsset {
 interface LibraryClientProps {
   initialItems: LibraryAsset[];
   initialNextCursor: string | null;
+  initialTotal: number;
   initialBrands: LibraryBrand[];
+  facetBrands: BrandOption[];
+  facetCampaigns: CampaignOption[];
+  facetTags: TagOption[];
+  hasMixedStatuses: boolean;
 }
 
 // ---------------------------------------------------------------------------
-// Container — owns cursor state, fetches more pages, hosts the detail panel.
-// Composition: <LibraryClient> renders <LibraryGrid> + <LibraryDetailPanel>.
-// No boolean-prop sprawl: the panel's open state is derived from selection.
+// Outer container — owns the LibraryQueryProvider so every facet shares the
+// same URL-synced state. The inner <LibraryGridContainer> reads the query
+// and triggers fetches.
 // ---------------------------------------------------------------------------
 
-export function LibraryClient({
+export function LibraryClient(props: LibraryClientProps) {
+  return (
+    <LibraryQueryProvider>
+      <LibraryToolbar {...props} />
+      <LibraryGridContainer {...props} />
+    </LibraryQueryProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar — sticky FilterBar above the grid.
+// ---------------------------------------------------------------------------
+
+function LibraryToolbar({
+  facetBrands,
+  facetCampaigns,
+  facetTags,
+  hasMixedStatuses,
+}: LibraryClientProps) {
+  return (
+    <FilterBar>
+      <div className="flex items-center gap-2">
+        <FilterBar.Search>
+          <SearchInput>
+            <SearchInput.Field />
+            <SearchInput.ModeToggle />
+          </SearchInput>
+        </FilterBar.Search>
+        <FilterBar.Facets>
+          <BrandFacet brands={facetBrands} />
+          <CampaignFacet campaigns={facetCampaigns} />
+          <TagFacet tags={facetTags} />
+          <FilterBar.More>
+            <SourceFacet />
+            <StatusFacet visible={hasMixedStatuses} />
+          </FilterBar.More>
+        </FilterBar.Facets>
+        <FilterBar.MobileSheet
+          brands={facetBrands}
+          campaigns={facetCampaigns}
+          tags={facetTags}
+          hasMixedStatuses={hasMixedStatuses}
+        />
+      </div>
+      <FilterBar.Summary
+        brands={facetBrands}
+        campaigns={facetCampaigns}
+        tags={facetTags}
+      />
+    </FilterBar>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grid container — owns the items state, fetches on URL change, hosts the
+// detail panel. Initial paint is server-rendered (no filters, page 1) so
+// TTFB stays tight. Once the URL has filters or search, we re-fetch.
+// ---------------------------------------------------------------------------
+
+function LibraryGridContainer({
   initialItems,
   initialNextCursor,
+  initialTotal,
   initialBrands,
 }: LibraryClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setResultsCount, isPending, query, activeCount, clearAll } =
+    useLibraryQuery();
+
   const [items, setItems] = useState<LibraryAsset[]>(initialItems);
-  const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    initialNextCursor
+  );
   const [loadingMore, setLoadingMore] = useState(false);
+  const [loadingPage, setLoadingPage] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [brands, setBrands] = useState<LibraryBrand[]>(initialBrands);
 
+  // Seed the first count immediately so the summary line doesn't flicker on
+  // the initial render with filters that match the server-hydrated set.
+  useEffect(() => {
+    setResultsCount(initialTotal);
+    // Intentionally only on mount — subsequent updates come from fetch
+    // responses.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Tracks the cursor of an in-flight request. Synchronous (a ref, not state)
+  // so two observer callbacks firing back-to-back can't both fetch the same
+  // page and produce duplicate React keys.
+  const inFlightCursorRef = useRef<string | null>(null);
+  const lastQueryStringRef = useRef<string>(searchParams.toString());
+
+  // Whenever the URL filter state changes, refetch page 1 with those filters.
+  useEffect(() => {
+    const next = searchParams.toString();
+    if (next === lastQueryStringRef.current) return;
+    lastQueryStringRef.current = next;
+
+    let cancelled = false;
+    setLoadingPage(true);
+
+    const sp = serializeLibraryQuery(parseLibraryQuery(searchParams));
+    sp.set("limit", "50");
+
+    fetch(`/api/library?${sp.toString()}`, { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        return (await res.json()) as {
+          items: LibraryAsset[];
+          nextCursor: string | null;
+          total: number;
+        };
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setItems(data.items);
+        setNextCursor(data.nextCursor);
+        setResultsCount(data.total);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        toast.error("Couldn't apply filters. Try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingPage(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, setResultsCount]);
 
   const loadMore = useCallback(
     async (cursor: string) => {
+      if (inFlightCursorRef.current === cursor) return;
+      inFlightCursorRef.current = cursor;
       setLoadingMore(true);
       try {
-        const params = new URLSearchParams({ limit: "30", cursor });
-        const res = await fetch(`/api/library?${params.toString()}`);
+        const sp = serializeLibraryQuery(parseLibraryQuery(searchParams));
+        sp.set("limit", "30");
+        sp.set("cursor", cursor);
+        const res = await fetch(`/api/library?${sp.toString()}`);
         if (!res.ok) throw new Error(`status ${res.status}`);
         const data = (await res.json()) as {
           items: LibraryAsset[];
           nextCursor: string | null;
+          total: number;
         };
-        setItems((prev) => [...prev, ...data.items]);
+        setItems((prev) => {
+          const seen = new Set(prev.map((it) => it.id));
+          const fresh = data.items.filter((it) => !seen.has(it.id));
+          return fresh.length === data.items.length
+            ? [...prev, ...data.items]
+            : [...prev, ...fresh];
+        });
         setNextCursor(data.nextCursor);
+        setResultsCount(data.total);
       } catch {
         toast.error("Couldn't load more assets. Try again.");
       } finally {
+        inFlightCursorRef.current = null;
         setLoadingMore(false);
       }
     },
-    []
+    [searchParams, setResultsCount]
   );
 
-  // Cursor-driven infinite scroll. IntersectionObserver beats a scroll-listener
-  // here — no rAF throttling needed, observer fires once per intersection.
+  // Cursor-driven infinite scroll. Disabled while a full-page filter fetch
+  // is in flight so we don't double-spinner.
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
     if (!nextCursor) return;
+    if (loadingPage) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -98,9 +264,8 @@ export function LibraryClient({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [nextCursor, loadingMore, loadMore]);
+  }, [nextCursor, loadingMore, loadingPage, loadMore]);
 
-  // Keep `brands` fresh after a pin toggle — anchor lists live on brand rows.
   const refreshBrands = useCallback(async () => {
     try {
       const res = await fetch("/api/brands");
@@ -111,10 +276,6 @@ export function LibraryClient({
         color: string;
         isPersonal: boolean;
       }>;
-      // Keep our anchor map authoritative — brands API doesn't include
-      // anchorAssetIds on the list endpoint. We patch them in via a per-brand
-      // GET on first need, but for the toggle UI the previous list + the
-      // panel's local update is enough to stay in sync.
       setBrands((prev) => {
         const byId = new Map(prev.map((b) => [b.id, b]));
         return rows.map((r) => ({
@@ -130,12 +291,9 @@ export function LibraryClient({
     }
   }, []);
 
-  const handleAssetUpdate = useCallback(
-    (next: LibraryAsset) => {
-      setItems((prev) => prev.map((it) => (it.id === next.id ? next : it)));
-    },
-    []
-  );
+  const handleAssetUpdate = useCallback((next: LibraryAsset) => {
+    setItems((prev) => prev.map((it) => (it.id === next.id ? next : it)));
+  }, []);
 
   const handleAssetDelete = useCallback((id: string) => {
     setItems((prev) => prev.filter((it) => it.id !== id));
@@ -153,8 +311,6 @@ export function LibraryClient({
           return { ...b, anchorAssetIds: Array.from(set) };
         })
       );
-      // Best-effort refresh in the background so we pick up server-side
-      // anchor-list invariants (e.g. dedupe, max-16 enforcement).
       refreshBrands();
     },
     [refreshBrands]
@@ -164,26 +320,50 @@ export function LibraryClient({
     ? items.find((it) => it.id === selectedId) ?? null
     : null;
 
-  if (items.length === 0) {
-    return <LibraryEmptyState />;
-  }
+  // Empty states differ based on whether filters are active.
+  const isEmpty = items.length === 0 && !loadingPage;
+  const filteredEmpty = isEmpty && activeCount > 0;
+  const blankEmpty = isEmpty && activeCount === 0;
+
+  // Suppress mismatch suspicion: `useRouter` is used only for the empty-state
+  // CTAs; not needed in the main render path.
+  void router;
 
   return (
-    <>
-      <LibraryGrid items={items} onSelect={setSelectedId} />
+    <div className="space-y-4 pt-2">
+      <div
+        // Subtle dim while a transition or filter fetch is pending — keeps
+        // the user oriented without ripping the grid out from under them.
+        className={cn(
+          "transition-opacity duration-150",
+          (isPending || loadingPage) && items.length > 0 && "opacity-60"
+        )}
+        aria-busy={isPending || loadingPage || undefined}
+      >
+        {blankEmpty && <LibraryBlankEmptyState />}
+        {filteredEmpty && (
+          <LibraryFilteredEmpty
+            query={query}
+            onClearAll={clearAll}
+          />
+        )}
+        {!isEmpty && <LibraryGrid items={items} onSelect={setSelectedId} />}
 
-      {/* Sentinel + spinner. Sentinel is always rendered when more pages exist
-          so the observer keeps a target after each successful page. */}
-      {nextCursor && <div ref={sentinelRef} className="h-4" aria-hidden />}
-      {loadingMore && (
-        <div
-          role="status"
-          aria-label="Loading more assets"
-          className="flex justify-center py-6"
-        >
-          <Loader2 className="size-5 animate-spin text-muted-foreground" />
-        </div>
-      )}
+        {/* Sentinel + spinner. Sentinel is always rendered when more pages exist
+            so the observer keeps a target after each successful page. */}
+        {nextCursor && !loadingPage && (
+          <div ref={sentinelRef} className="h-4" aria-hidden />
+        )}
+        {loadingMore && (
+          <div
+            role="status"
+            aria-label="Loading more assets"
+            className="flex justify-center py-6"
+          >
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+      </div>
 
       <LibraryDetailPanel
         asset={selected}
@@ -193,7 +373,7 @@ export function LibraryClient({
         onAssetDelete={handleAssetDelete}
         onBrandPinChange={handleBrandPinChange}
       />
-    </>
+    </div>
   );
 }
 
@@ -226,9 +406,6 @@ function LibraryGrid({
 
 // ---------------------------------------------------------------------------
 // Card — square thumbnail, source badge, hover overlay with metadata.
-// Mirrors references-client's visual treatment but adds a source badge and
-// wires through tags. Plain <img> matches the rest of the codebase (signed
-// R2 URLs aren't on the next.config remotePatterns allow-list).
 // ---------------------------------------------------------------------------
 
 function LibraryCard({
@@ -262,12 +439,10 @@ function LibraryCard({
           decoding="async"
         />
 
-        {/* Source badge — top-left so it doesn't fight the usage count. */}
         <div className="absolute left-2 top-2">
           <SourceBadge source={asset.source} />
         </div>
 
-        {/* Usage count — only when > 0; tabular-nums so the box doesn't jump. */}
         {asset.usageCount > 0 && (
           <div className="absolute right-2 top-2 inline-flex items-center gap-0.5 rounded-md bg-background/70 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-foreground backdrop-blur-sm">
             <Hash className="size-2.5" aria-hidden />
@@ -275,7 +450,6 @@ function LibraryCard({
           </div>
         )}
 
-        {/* Hover overlay — fades in metadata + dimensions chip. */}
         <div className="pointer-events-none absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/75 via-black/20 to-transparent p-3 opacity-0 transition-opacity duration-150 group-hover/card:opacity-100 group-focus-visible/card:opacity-100">
           {asset.fileName && (
             <p className="line-clamp-1 text-xs font-medium text-white/95">
@@ -310,7 +484,6 @@ function LibraryCard({
 
 // ---------------------------------------------------------------------------
 // Source badge — three explicit variants so we don't pile booleans on Badge.
-// Tinted, not filled — matches the destructive-style convention.
 // ---------------------------------------------------------------------------
 
 function SourceBadge({ source }: { source: AssetSource }) {
@@ -321,9 +494,6 @@ function SourceBadge({ source }: { source: AssetSource }) {
       ? "Generated"
       : "Imported";
 
-  // Each source gets a single token-based tint. We avoid raw color literals;
-  // primary covers generated (the magical path), muted covers uploads,
-  // accent covers imports — all already first-class semantic tokens.
   const variantClass =
     source === "generated"
       ? "bg-primary/15 text-primary ring-primary/25"
@@ -348,10 +518,12 @@ function SourceBadge({ source }: { source: AssetSource }) {
 }
 
 // ---------------------------------------------------------------------------
-// Empty state — short, encouraging, action-oriented per the voice guide.
+// Empty states — two distinct shapes per the design brief.
+//   1. Blank library (no items, no filters) — encourage upload/generate.
+//   2. Filtered empty (filters active, zero matches) — explain + offer clear.
 // ---------------------------------------------------------------------------
 
-function LibraryEmptyState() {
+function LibraryBlankEmptyState() {
   const router = useRouter();
   return (
     <div
@@ -375,9 +547,7 @@ function LibraryEmptyState() {
         </Button>
         <Button
           variant="outline"
-          onClick={() =>
-            router.push("/generate?focus=imageInput")
-          }
+          onClick={() => router.push("/generate?focus=imageInput")}
         >
           <ImagePlus aria-hidden />
           Upload a reference
@@ -387,9 +557,41 @@ function LibraryEmptyState() {
   );
 }
 
+function LibraryFilteredEmpty({
+  onClearAll,
+}: {
+  query: ReturnType<typeof useLibraryQuery>["query"];
+  onClearAll: () => void;
+}) {
+  // TODO(library-dam Phase 5): when the API returns `dropFilterCounts`, render
+  // a "Drop X (+N results)" CTA next to "Clear all filters" for the most-
+  // restrictive facet.
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center rounded-2xl bg-card px-6 py-16 text-center ring-1 ring-foreground/10"
+    >
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-muted/40 text-muted-foreground">
+        <SearchX className="size-7" strokeWidth={1.5} aria-hidden />
+      </div>
+      <h3 className="font-heading text-lg font-semibold">
+        No matches for these filters.
+      </h3>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        Try removing the brand or broadening tags.
+      </p>
+      <div className="mt-5">
+        <Button variant="outline" onClick={onClearAll}>
+          Clear all filters
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
-// Skeleton (unused on first paint — page.tsx ships data — kept for the
-// dynamic import / CSR fallback the picker may eventually wire up.)
+// Skeleton (kept for the dynamic import / CSR fallback the picker may
+// eventually wire up).
 // ---------------------------------------------------------------------------
 
 export function LibrarySkeletonGrid() {

--- a/src/app/(dashboard)/library/page.tsx
+++ b/src/app/(dashboard)/library/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from "next/navigation";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import {
@@ -12,6 +12,11 @@ import {
 import { env } from "@/lib/env";
 import { getAssetUrl } from "@/lib/storage";
 import { LibraryClient, type LibraryAsset } from "./library-client";
+import type {
+  BrandOption,
+  CampaignOption,
+  TagOption,
+} from "./filter-bar";
 
 const INITIAL_LIMIT = 30;
 
@@ -29,11 +34,13 @@ export default async function LibraryPage() {
 
   const userId = session.user.id;
 
-  // First page: read directly from drizzle to keep TTFB tight (mirrors the
-  // server-side path the backend agent's GET /api/library will take). Cursor
-  // pagination is `createdAt` strictly less-than (matches the references API
-  // contract the picker already consumes).
-  const rows = await db
+  // First page: read directly from drizzle to keep TTFB tight. Cursor
+  // pagination is `(createdAt, id)` lexicographic so sub-millisecond inserts
+  // can't cause duplicates or skips.
+  //
+  // We additionally compute the total count via a window function so the
+  // FilterBar's summary can show "N results" without a second round-trip.
+  const initialRows = await db
     .select({
       id: assets.id,
       userId: assets.userId,
@@ -50,18 +57,19 @@ export default async function LibraryPage() {
       usageCount: assets.usageCount,
       embeddedAt: assets.embeddedAt,
       createdAt: assets.createdAt,
+      totalCount: sql<number>`COUNT(*) OVER()`.as("total_count"),
     })
     .from(assets)
     .where(and(eq(assets.userId, userId)))
     .orderBy(desc(assets.createdAt), desc(assets.id))
     .limit(INITIAL_LIMIT + 1);
 
-  const hasMore = rows.length > INITIAL_LIMIT;
-  const trimmed = hasMore ? rows.slice(0, INITIAL_LIMIT) : rows;
+  const hasMore = initialRows.length > INITIAL_LIMIT;
+  const trimmed = hasMore ? initialRows.slice(0, INITIAL_LIMIT) : initialRows;
   const ids = trimmed.map((r) => r.id);
+  const initialTotal = trimmed[0]?.totalCount ?? 0;
 
-  // Tags + campaigns in two follow-up batched queries — cheap because we
-  // already have the asset id set in memory.
+  // Tags + campaigns for the loaded items, in two batched queries.
   const [tagRows, campaignRows] = await Promise.all([
     ids.length
       ? db
@@ -97,7 +105,7 @@ export default async function LibraryPage() {
     campaignsById.set(row.assetId, list);
   }
 
-  // Resolve thumbnail + full URLs once — Cloudflare R2 keys → signed URLs.
+  // Resolve thumbnail + full URLs once.
   const initialItems: LibraryAsset[] = await Promise.all(
     trimmed.map(async (r) => {
       const url = await getAssetUrl(r.r2Key);
@@ -125,20 +133,55 @@ export default async function LibraryPage() {
     })
   );
 
-  // Brand list for the pin-to-brand toggle in the detail panel. Cheap because
-  // we own the workspace lookup already; reuse the same scoping the layout
-  // uses (own-personal-or-real-brand). Fetched here so the panel doesn't have
-  // to round-trip on first open.
-  const brandRows = await db
-    .select({
-      id: brands.id,
-      name: brands.name,
-      color: brands.color,
-      isPersonal: brands.isPersonal,
-      anchorAssetIds: brands.anchorAssetIds,
-    })
-    .from(brands)
-    .where(eq(brands.ownerId, userId));
+  // -----------------------------------------------------------------------
+  // FilterBar option lists. All scoped to the user's owned brands so the
+  // facets only show choices that actually appear in their library.
+  //
+  // Run these in parallel — each is a single index hit, total ~four cheap
+  // round-trips that overlap with the asset hydration above.
+  // -----------------------------------------------------------------------
+  const [
+    brandRows,
+    facetCampaignRows,
+    facetTagRows,
+    distinctStatusRows,
+  ] = await Promise.all([
+    db
+      .select({
+        id: brands.id,
+        name: brands.name,
+        color: brands.color,
+        isPersonal: brands.isPersonal,
+        anchorAssetIds: brands.anchorAssetIds,
+      })
+      .from(brands)
+      .where(eq(brands.ownerId, userId)),
+    // Campaigns whose brand is owned by this user.
+    db
+      .select({
+        id: campaigns.id,
+        name: campaigns.name,
+        brandId: campaigns.brandId,
+      })
+      .from(campaigns)
+      .innerJoin(brands, eq(brands.id, campaigns.brandId))
+      .where(eq(brands.ownerId, userId))
+      .orderBy(campaigns.name),
+    // Distinct tag names the user has on any of their assets.
+    db
+      .selectDistinct({ tag: assetTags.tag })
+      .from(assetTags)
+      .innerJoin(assets, eq(assets.id, assetTags.assetId))
+      .where(eq(assets.userId, userId))
+      .orderBy(assetTags.tag),
+    // Distinct status values across the user's assets — used to gate the
+    // Status section in the More popover. We hide it when only one value
+    // exists so solo creators don't see a useless control.
+    db
+      .selectDistinct({ status: assets.status })
+      .from(assets)
+      .where(eq(assets.userId, userId)),
+  ]);
 
   const initialBrands = brandRows.map((b) => ({
     id: b.id,
@@ -148,8 +191,25 @@ export default async function LibraryPage() {
     anchorAssetIds: (b.anchorAssetIds ?? []) as string[],
   }));
 
+  const facetBrands: BrandOption[] = brandRows
+    .map((b) => ({ id: b.id, name: b.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const facetCampaigns: CampaignOption[] = facetCampaignRows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    brandId: c.brandId,
+  }));
+
+  const facetTags: TagOption[] = facetTagRows.map((r) => ({
+    id: r.tag,
+    label: r.tag,
+  }));
+
+  const hasMixedStatuses = distinctStatusRows.length > 1;
+
   const initialNextCursor = hasMore
-    ? trimmed[trimmed.length - 1].createdAt.toISOString()
+    ? `${trimmed[trimmed.length - 1].createdAt.toISOString()}__${trimmed[trimmed.length - 1].id}`
     : null;
 
   return (
@@ -164,7 +224,12 @@ export default async function LibraryPage() {
       <LibraryClient
         initialItems={initialItems}
         initialNextCursor={initialNextCursor}
+        initialTotal={initialTotal}
         initialBrands={initialBrands}
+        facetBrands={facetBrands}
+        facetCampaigns={facetCampaigns}
+        facetTags={facetTags}
+        hasMixedStatuses={hasMixedStatuses}
       />
     </div>
   );

--- a/src/app/(dashboard)/library/page.tsx
+++ b/src/app/(dashboard)/library/page.tsx
@@ -1,0 +1,171 @@
+import { notFound, redirect } from "next/navigation";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  assets,
+  assetCampaigns,
+  assetTags,
+  brands,
+  campaigns,
+} from "@/lib/db/schema";
+import { env } from "@/lib/env";
+import { getAssetUrl } from "@/lib/storage";
+import { LibraryClient, type LibraryAsset } from "./library-client";
+
+const INITIAL_LIMIT = 30;
+
+export const dynamic = "force-dynamic";
+
+export default async function LibraryPage() {
+  if (!env.LIBRARY_DAM_ENABLED) {
+    notFound();
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const userId = session.user.id;
+
+  // First page: read directly from drizzle to keep TTFB tight (mirrors the
+  // server-side path the backend agent's GET /api/library will take). Cursor
+  // pagination is `createdAt` strictly less-than (matches the references API
+  // contract the picker already consumes).
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      source: assets.source,
+      mediaType: assets.mediaType,
+      r2Key: assets.r2Key,
+      r2Url: assets.r2Url,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      fileName: assets.fileName,
+      fileSize: assets.fileSize,
+      width: assets.width,
+      height: assets.height,
+      usageCount: assets.usageCount,
+      embeddedAt: assets.embeddedAt,
+      createdAt: assets.createdAt,
+    })
+    .from(assets)
+    .where(and(eq(assets.userId, userId)))
+    .orderBy(desc(assets.createdAt), desc(assets.id))
+    .limit(INITIAL_LIMIT + 1);
+
+  const hasMore = rows.length > INITIAL_LIMIT;
+  const trimmed = hasMore ? rows.slice(0, INITIAL_LIMIT) : rows;
+  const ids = trimmed.map((r) => r.id);
+
+  // Tags + campaigns in two follow-up batched queries — cheap because we
+  // already have the asset id set in memory.
+  const [tagRows, campaignRows] = await Promise.all([
+    ids.length
+      ? db
+          .select({ assetId: assetTags.assetId, tag: assetTags.tag })
+          .from(assetTags)
+          .where(inArray(assetTags.assetId, ids))
+      : Promise.resolve([] as { assetId: string; tag: string }[]),
+    ids.length
+      ? db
+          .select({
+            assetId: assetCampaigns.assetId,
+            campaignId: assetCampaigns.campaignId,
+            campaignName: campaigns.name,
+          })
+          .from(assetCampaigns)
+          .innerJoin(campaigns, eq(campaigns.id, assetCampaigns.campaignId))
+          .where(inArray(assetCampaigns.assetId, ids))
+      : Promise.resolve(
+          [] as { assetId: string; campaignId: string; campaignName: string }[]
+        ),
+  ]);
+
+  const tagsById = new Map<string, string[]>();
+  for (const row of tagRows) {
+    const list = tagsById.get(row.assetId) ?? [];
+    list.push(row.tag);
+    tagsById.set(row.assetId, list);
+  }
+  const campaignsById = new Map<string, string[]>();
+  for (const row of campaignRows) {
+    const list = campaignsById.get(row.assetId) ?? [];
+    list.push(row.campaignName);
+    campaignsById.set(row.assetId, list);
+  }
+
+  // Resolve thumbnail + full URLs once — Cloudflare R2 keys → signed URLs.
+  const initialItems: LibraryAsset[] = await Promise.all(
+    trimmed.map(async (r) => {
+      const url = await getAssetUrl(r.r2Key);
+      const thumbnailUrl = r.thumbnailR2Key
+        ? await getAssetUrl(r.thumbnailR2Key)
+        : url;
+      return {
+        id: r.id,
+        userId: r.userId,
+        brandId: r.brandId,
+        source: r.source,
+        mediaType: r.mediaType,
+        url,
+        thumbnailUrl,
+        fileName: r.fileName,
+        fileSize: r.fileSize,
+        width: r.width,
+        height: r.height,
+        usageCount: r.usageCount,
+        embeddedAt: r.embeddedAt ? r.embeddedAt.toISOString() : null,
+        createdAt: r.createdAt.toISOString(),
+        tags: tagsById.get(r.id) ?? [],
+        campaigns: campaignsById.get(r.id) ?? [],
+      };
+    })
+  );
+
+  // Brand list for the pin-to-brand toggle in the detail panel. Cheap because
+  // we own the workspace lookup already; reuse the same scoping the layout
+  // uses (own-personal-or-real-brand). Fetched here so the panel doesn't have
+  // to round-trip on first open.
+  const brandRows = await db
+    .select({
+      id: brands.id,
+      name: brands.name,
+      color: brands.color,
+      isPersonal: brands.isPersonal,
+      anchorAssetIds: brands.anchorAssetIds,
+    })
+    .from(brands)
+    .where(eq(brands.ownerId, userId));
+
+  const initialBrands = brandRows.map((b) => ({
+    id: b.id,
+    name: b.name,
+    color: b.color,
+    isPersonal: b.isPersonal,
+    anchorAssetIds: (b.anchorAssetIds ?? []) as string[],
+  }));
+
+  const initialNextCursor = hasMore
+    ? trimmed[trimmed.length - 1].createdAt.toISOString()
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Library</h1>
+        <p className="text-muted-foreground mt-1">
+          Every upload, generation, and import — in one place. Tag, pin, and
+          reuse.
+        </p>
+      </div>
+      <LibraryClient
+        initialItems={initialItems}
+        initialNextCursor={initialNextCursor}
+        initialBrands={initialBrands}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/library/page.tsx
+++ b/src/app/(dashboard)/library/page.tsx
@@ -7,10 +7,14 @@ import {
   assetCampaigns,
   assetTags,
   brands,
+  brandMembers,
   campaigns,
+  users,
 } from "@/lib/db/schema";
 import { env } from "@/lib/env";
 import { getAssetUrl } from "@/lib/storage";
+import { getCurrentWorkspace } from "@/lib/workspace/context";
+import { loadRoleContext, isWorkspaceAdmin } from "@/lib/workspace/permissions";
 import { LibraryClient, type LibraryAsset } from "./library-client";
 import type {
   BrandOption,
@@ -34,12 +38,24 @@ export default async function LibraryPage() {
 
   const userId = session.user.id;
 
+  // Workspace + admin context. Admins see every asset in the workspace;
+  // members see only their own. Resolved up front so the same flag drives
+  // the asset scope and the brand/campaign facet scope below.
+  const workspace = await getCurrentWorkspace(userId);
+  const isAdmin = workspace
+    ? isWorkspaceAdmin(await loadRoleContext(userId, workspace.id))
+    : false;
+
   // First page: read directly from drizzle to keep TTFB tight. Cursor
   // pagination is `(createdAt, id)` lexicographic so sub-millisecond inserts
   // can't cause duplicates or skips.
   //
   // We additionally compute the total count via a window function so the
   // FilterBar's summary can show "N results" without a second round-trip.
+  const assetScope = isAdmin && workspace
+    ? sql`${assets.brandId} IN (SELECT id FROM brands WHERE workspace_id = ${workspace.id})`
+    : eq(assets.userId, userId);
+
   const initialRows = await db
     .select({
       id: assets.id,
@@ -55,12 +71,18 @@ export default async function LibraryPage() {
       width: assets.width,
       height: assets.height,
       usageCount: assets.usageCount,
+      status: assets.status,
       embeddedAt: assets.embeddedAt,
       createdAt: assets.createdAt,
+      creatorId: users.id,
+      creatorName: users.name,
+      creatorImage: users.image,
+      creatorEmail: users.email,
       totalCount: sql<number>`COUNT(*) OVER()`.as("total_count"),
     })
     .from(assets)
-    .where(and(eq(assets.userId, userId)))
+    .leftJoin(users, eq(users.id, assets.userId))
+    .where(assetScope)
     .orderBy(desc(assets.createdAt), desc(assets.id))
     .limit(INITIAL_LIMIT + 1);
 
@@ -125,6 +147,15 @@ export default async function LibraryPage() {
         width: r.width,
         height: r.height,
         usageCount: r.usageCount,
+        status: r.status,
+        creator: r.creatorId
+          ? {
+              id: r.creatorId,
+              name: r.creatorName,
+              image: r.creatorImage,
+              email: r.creatorEmail,
+            }
+          : null,
         embeddedAt: r.embeddedAt ? r.embeddedAt.toISOString() : null,
         createdAt: r.createdAt.toISOString(),
         tags: tagsById.get(r.id) ?? [],
@@ -134,53 +165,119 @@ export default async function LibraryPage() {
   );
 
   // -----------------------------------------------------------------------
-  // FilterBar option lists. All scoped to the user's owned brands so the
-  // facets only show choices that actually appear in their library.
+  // FilterBar option lists. Brands + campaigns are scoped to the active
+  // workspace using the same rules as the sidebar's BrandList: workspace
+  // admins see every brand in the workspace, members see only the brands
+  // they belong to via brand_members. This keeps the Brand facet in sync
+  // with what the user already sees in the sidebar.
   //
   // Run these in parallel — each is a single index hit, total ~four cheap
   // round-trips that overlap with the asset hydration above.
   // -----------------------------------------------------------------------
+  // For personal brands we surface the owner's identity (name + avatar) so an
+  // admin viewing several teammates' personal libraries can tell them apart.
+  // The user join is LEFT so non-personal brands (no ownerId) still come back.
+  const brandSelect = {
+    id: brands.id,
+    name: brands.name,
+    color: brands.color,
+    isPersonal: brands.isPersonal,
+    ownerId: brands.ownerId,
+    ownerName: users.name,
+    ownerImage: users.image,
+    ownerEmail: users.email,
+    anchorAssetIds: brands.anchorAssetIds,
+  } as const;
+
+  type BrandRow = {
+    id: string;
+    name: string;
+    color: string;
+    isPersonal: boolean;
+    ownerId: string | null;
+    ownerName: string | null;
+    ownerImage: string | null;
+    ownerEmail: string | null;
+    anchorAssetIds: unknown;
+  };
+
+  const brandsQuery: Promise<BrandRow[]> = !workspace
+    ? Promise.resolve([])
+    : isAdmin
+    ? db
+        .select(brandSelect)
+        .from(brands)
+        .leftJoin(users, eq(users.id, brands.ownerId))
+        .where(eq(brands.workspaceId, workspace.id))
+        .orderBy(brands.name)
+    : db
+        .select(brandSelect)
+        .from(brands)
+        .innerJoin(brandMembers, eq(brandMembers.brandId, brands.id))
+        .leftJoin(users, eq(users.id, brands.ownerId))
+        .where(
+          and(
+            eq(brands.workspaceId, workspace.id),
+            eq(brandMembers.userId, userId)
+          )
+        )
+        .orderBy(brands.name);
+
+  const campaignsQuery = !workspace
+    ? Promise.resolve(
+        [] as Array<{ id: string; name: string; brandId: string }>
+      )
+    : isAdmin
+    ? db
+        .select({
+          id: campaigns.id,
+          name: campaigns.name,
+          brandId: campaigns.brandId,
+        })
+        .from(campaigns)
+        .innerJoin(brands, eq(brands.id, campaigns.brandId))
+        .where(eq(brands.workspaceId, workspace.id))
+        .orderBy(campaigns.name)
+    : db
+        .select({
+          id: campaigns.id,
+          name: campaigns.name,
+          brandId: campaigns.brandId,
+        })
+        .from(campaigns)
+        .innerJoin(brands, eq(brands.id, campaigns.brandId))
+        .innerJoin(brandMembers, eq(brandMembers.brandId, brands.id))
+        .where(
+          and(
+            eq(brands.workspaceId, workspace.id),
+            eq(brandMembers.userId, userId)
+          )
+        )
+        .orderBy(campaigns.name);
+
   const [
     brandRows,
     facetCampaignRows,
     facetTagRows,
     distinctStatusRows,
   ] = await Promise.all([
-    db
-      .select({
-        id: brands.id,
-        name: brands.name,
-        color: brands.color,
-        isPersonal: brands.isPersonal,
-        anchorAssetIds: brands.anchorAssetIds,
-      })
-      .from(brands)
-      .where(eq(brands.ownerId, userId)),
-    // Campaigns whose brand is owned by this user.
-    db
-      .select({
-        id: campaigns.id,
-        name: campaigns.name,
-        brandId: campaigns.brandId,
-      })
-      .from(campaigns)
-      .innerJoin(brands, eq(brands.id, campaigns.brandId))
-      .where(eq(brands.ownerId, userId))
-      .orderBy(campaigns.name),
-    // Distinct tag names the user has on any of their assets.
+    brandsQuery,
+    campaignsQuery,
+    // Distinct tag names across the assets the user can see (workspace-wide
+    // for admins, own-only for members) so the Tag facet matches the grid.
     db
       .selectDistinct({ tag: assetTags.tag })
       .from(assetTags)
       .innerJoin(assets, eq(assets.id, assetTags.assetId))
-      .where(eq(assets.userId, userId))
+      .where(assetScope)
       .orderBy(assetTags.tag),
-    // Distinct status values across the user's assets — used to gate the
-    // Status section in the More popover. We hide it when only one value
-    // exists so solo creators don't see a useless control.
+    // Distinct status values — used to gate the Status section in the More
+    // popover. We hide it when only one value exists so solo creators don't
+    // see a useless control.
     db
       .selectDistinct({ status: assets.status })
       .from(assets)
-      .where(eq(assets.userId, userId)),
+      .where(assetScope),
   ]);
 
   const initialBrands = brandRows.map((b) => ({
@@ -191,9 +288,32 @@ export default async function LibraryPage() {
     anchorAssetIds: (b.anchorAssetIds ?? []) as string[],
   }));
 
+  // Personal brands literally store name="Personal", which is useless when
+  // an admin sees several side by side. Surface the owner's display name
+  // (falling back to email local-part, then "Personal") so they're
+  // distinguishable in the dropdown.
   const facetBrands: BrandOption[] = brandRows
-    .map((b) => ({ id: b.id, name: b.name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .map((b) => {
+      const ownerLabel =
+        b.isPersonal
+          ? b.ownerName?.trim() ||
+            b.ownerEmail?.split("@")[0] ||
+            b.name
+          : b.name;
+      return {
+        id: b.id,
+        name: ownerLabel,
+        isPersonal: b.isPersonal,
+        ownerImage: b.isPersonal ? b.ownerImage : null,
+      };
+    })
+    .sort((a, b) => {
+      // Pin personal brands to the top of the dropdown, alphabetised within
+      // each group — matches how the sidebar groups them.
+      if (a.isPersonal && !b.isPersonal) return -1;
+      if (!a.isPersonal && b.isPersonal) return 1;
+      return a.name.localeCompare(b.name);
+    });
 
   const facetCampaigns: CampaignOption[] = facetCampaignRows.map((c) => ({
     id: c.id,

--- a/src/app/(dashboard)/library/search-input.tsx
+++ b/src/app/(dashboard)/library/search-input.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * SearchInput — the toolbar's primary text-search affordance.
+ *
+ * Phase 4 ships:
+ *   - Debounced 250ms text-search (writes to URL `q` via useLibraryQuery).
+ *   - Global ⌘K + `/` focus shortcut (suppressed when another input is focused).
+ *   - Esc clears `q` if non-empty, otherwise blurs.
+ *
+ * Phase 5 (T039) will fill in <SearchInput.ModeToggle /> with text/semantic/
+ * hybrid Popover. The slot is reserved here so the composition stays correct
+ * even though the toggle is invisible today.
+ *
+ * Composition rules:
+ *   - No boolean props: ModeToggle is a child slot, not a `showModeToggle`
+ *     boolean on Field.
+ *   - State lives in useLibraryQuery() — Field is a thin URL projector with a
+ *     local debounce timer so each keystroke doesn't shove a router transition.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { useLibraryQuery } from "./use-library-query";
+
+const DEBOUNCE_MS = 250;
+
+// ---------------------------------------------------------------------------
+// SearchInput — root composes the slots. Doesn't render its own DOM beyond
+// the children container, so consumers can layout the field + (future) toggle
+// however they like.
+// ---------------------------------------------------------------------------
+
+interface SearchInputProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SearchInput({ children, className }: SearchInputProps) {
+  return (
+    <div
+      data-slot="library-search"
+      className={cn("flex min-w-0 flex-1 items-center gap-2", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field — InputGroup wrapping the actual text input. Debounces local state
+// into useLibraryQuery's setQuery so the URL update isn't on the keystroke
+// hot path. The local input value mirrors the URL on mount + when the URL
+// changes from outside (back button, deep link).
+// ---------------------------------------------------------------------------
+
+interface FieldProps {
+  placeholder?: string;
+  className?: string;
+}
+
+function Field({
+  placeholder = "Search assets…",
+  className,
+}: FieldProps) {
+  const { query, setQuery } = useLibraryQuery();
+  const [local, setLocal] = useState(query.q);
+  // Track the URL `q` we last synced from. When it changes (deep link, back
+  // nav, clearAll), pull the new value into local — unless the input is
+  // currently focused (the user is typing; don't fight them).
+  // This is the React 19 "set state during render" pattern, which avoids
+  // setState-in-effect cascading renders.
+  const [syncedFromQ, setSyncedFromQ] = useState(query.q);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  if (query.q !== syncedFromQ) {
+    setSyncedFromQ(query.q);
+    // Mirror the URL value into local. Done at render time (not in an
+    // effect) so React 19's strict "no setState in effect" rule is happy.
+    // If the user is mid-debounce, their next keystroke will overwrite this
+    // value and re-arm the debounce — keystrokes always win.
+    setLocal(query.q);
+  }
+
+  const flush = useCallback(
+    (value: string) => {
+      setQuery({ q: value });
+    },
+    [setQuery]
+  );
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const next = e.target.value;
+      setLocal(next);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => flush(next), DEBOUNCE_MS);
+    },
+    [flush]
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        if (local) {
+          // First Esc clears; the field stays focused so the user can keep typing.
+          e.preventDefault();
+          if (debounceRef.current) clearTimeout(debounceRef.current);
+          setLocal("");
+          flush("");
+        } else {
+          inputRef.current?.blur();
+        }
+      } else if (e.key === "Enter") {
+        // Skip the debounce — the user has explicitly committed.
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        flush(local);
+      }
+    },
+    [local, flush]
+  );
+
+  // Global ⌘K and `/` to focus. `/` is gated to skip when another input/textarea
+  // already has focus so it doesn't steal keystrokes from the detail panel.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isMeta = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+      const isSlash =
+        e.key === "/" && !isFormElementFocused() && !e.metaKey && !e.ctrlKey;
+      if (isMeta || isSlash) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Clean up any pending debounce on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return (
+    <InputGroup className={cn("h-9 max-w-md", className)}>
+      <InputGroupAddon>
+        <Search className="size-4" aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput
+        ref={inputRef}
+        type="search"
+        value={local}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        aria-label="Search library"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <InputGroupAddon align="inline-end">
+        <kbd className="inline-flex h-5 items-center gap-0.5 rounded-sm bg-muted px-1.5 text-[10px] font-medium text-muted-foreground ring-1 ring-foreground/10">
+          ⌘K
+        </kbd>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ModeToggle — Phase 5 (T039) hybrid/semantic/text mode toggle slots in here.
+// Returns null in Phase 4 so the composition is correct without shipping
+// dead UI surface.
+// ---------------------------------------------------------------------------
+
+function ModeToggle() {
+  // Phase 5 (T039): hybrid/semantic/text mode toggle slots into this child.
+  return null;
+}
+
+SearchInput.Field = Field;
+SearchInput.ModeToggle = ModeToggle;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isFormElementFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (el instanceof HTMLElement && el.isContentEditable) return true;
+  return false;
+}

--- a/src/app/(dashboard)/library/use-library-query.tsx
+++ b/src/app/(dashboard)/library/use-library-query.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+/**
+ * useLibraryQuery — single source of truth for the Library's filter+search
+ * state. Owns the URL contract and exposes a patch-based mutation API so
+ * facets and the search input never reach for `useRouter` / `useSearchParams`
+ * directly. Built on `LibraryQueryProvider` so children get a stable context
+ * value and tests can swap in a memory-backed implementation.
+ *
+ * URL contract (Phase 4 — see specs/library-dam/plan.md):
+ *
+ *   /library
+ *     ?q=hero+shot          — text search
+ *     &brand=<uuid>         — single brand filter
+ *     &campaign=<uuid>      — single campaign filter
+ *     &tag=<uuid>           — repeatable; multi-tag
+ *     &tagOp=or             — `or` (default) or `and`
+ *     &source=generated     — repeatable; one of uploaded/generated/imported
+ *     &status=approved      — repeatable; assets.status enum
+ *     # mode=               — RESERVED for Phase 5 (semantic/hybrid). Read but
+ *                             not acted on by the API yet.
+ *
+ * Why a provider, not a hook-only API:
+ *   - We need stable identity for `setQuery`, `toggleTag`, `clearAll` so
+ *     facet popovers can pass them down without forcing re-render trees.
+ *   - The mobile sheet stages changes locally before applying — having the
+ *     provider as the canonical "live" state lets the sheet diff against it.
+ *   - `useTransition` lives once at the provider so URL pushes don't cascade
+ *     pending flags to every facet via prop drilling.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type ReactNode,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AssetSource = "uploaded" | "generated" | "imported";
+export type AssetStatus =
+  | "draft"
+  | "in_review"
+  | "approved"
+  | "rejected"
+  | "archived";
+export type TagOp = "or" | "and";
+
+export interface LibraryQuery {
+  q: string;
+  brand: string | null;
+  campaign: string | null;
+  tags: string[];
+  tagOp: TagOp;
+  sources: AssetSource[];
+  statuses: AssetStatus[];
+}
+
+export interface LibraryQueryContextValue {
+  query: LibraryQuery;
+  setQuery: (patch: Partial<LibraryQuery>) => void;
+  toggleTag: (tagId: string) => void;
+  clearAll: () => void;
+  resultsCount: number | null;
+  setResultsCount: (n: number | null) => void;
+  isPending: boolean;
+  activeCount: number;
+}
+
+const EMPTY_QUERY: LibraryQuery = {
+  q: "",
+  brand: null,
+  campaign: null,
+  tags: [],
+  tagOp: "or",
+  sources: [],
+  statuses: [],
+};
+
+// Whitelisted vocabularies — defensive parsing, never trust the URL.
+const VALID_SOURCES: ReadonlySet<AssetSource> = new Set([
+  "uploaded",
+  "generated",
+  "imported",
+]);
+const VALID_STATUSES: ReadonlySet<AssetStatus> = new Set([
+  "draft",
+  "in_review",
+  "approved",
+  "rejected",
+  "archived",
+]);
+
+// ---------------------------------------------------------------------------
+// URL <-> query (de)serialization
+// ---------------------------------------------------------------------------
+
+export function parseLibraryQuery(
+  params: URLSearchParams | ReadonlyURLSearchParams
+): LibraryQuery {
+  const sp =
+    params instanceof URLSearchParams
+      ? params
+      : new URLSearchParams(params.toString());
+
+  const tags = sp.getAll("tag").filter(Boolean);
+  const tagOpRaw = sp.get("tagOp");
+  const tagOp: TagOp = tagOpRaw === "and" ? "and" : "or";
+
+  const sources = sp
+    .getAll("source")
+    .filter((s): s is AssetSource =>
+      VALID_SOURCES.has(s as AssetSource)
+    );
+  const statuses = sp
+    .getAll("status")
+    .filter((s): s is AssetStatus =>
+      VALID_STATUSES.has(s as AssetStatus)
+    );
+
+  return {
+    q: sp.get("q") ?? "",
+    brand: sp.get("brand") || null,
+    campaign: sp.get("campaign") || null,
+    tags,
+    tagOp,
+    sources,
+    statuses,
+  };
+}
+
+export function serializeLibraryQuery(query: LibraryQuery): URLSearchParams {
+  const sp = new URLSearchParams();
+  if (query.q) sp.set("q", query.q);
+  if (query.brand) sp.set("brand", query.brand);
+  if (query.campaign) sp.set("campaign", query.campaign);
+  for (const t of query.tags) sp.append("tag", t);
+  // Only emit tagOp when AND — OR is the default.
+  if (query.tagOp === "and" && query.tags.length > 1) {
+    sp.set("tagOp", "and");
+  }
+  for (const s of query.sources) sp.append("source", s);
+  for (const s of query.statuses) sp.append("status", s);
+  return sp;
+}
+
+export function countActive(query: LibraryQuery): number {
+  let n = 0;
+  if (query.q) n++;
+  if (query.brand) n++;
+  if (query.campaign) n++;
+  if (query.tags.length > 0) n++;
+  if (query.sources.length > 0) n++;
+  if (query.statuses.length > 0) n++;
+  return n;
+}
+
+// `ReadonlyURLSearchParams` is what `useSearchParams()` returns. Type-only —
+// we don't import it because the type narrowing in `parseLibraryQuery` works
+// against a structural shape that both `URLSearchParams` and the readonly
+// version satisfy.
+type ReadonlyURLSearchParams = {
+  get(name: string): string | null;
+  getAll(name: string): string[];
+  toString(): string;
+};
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const LibraryQueryContext = createContext<LibraryQueryContextValue | null>(
+  null
+);
+
+export function useLibraryQuery(): LibraryQueryContextValue {
+  const ctx = useContext(LibraryQueryContext);
+  if (!ctx) {
+    throw new Error(
+      "useLibraryQuery must be used inside <LibraryQueryProvider>"
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Provider — URL-synced
+// ---------------------------------------------------------------------------
+
+export function LibraryQueryProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  // Reading the current query is derived from the URL — single source of
+  // truth. We `useMemo` over the searchParams string so identity is stable
+  // across renders that don't change the URL.
+  const query = useMemo(
+    () => parseLibraryQuery(searchParams),
+    [searchParams]
+  );
+
+  // Result count is owned by the consumer (the grid / fetcher) since the
+  // total comes back from the API response. We tag every count with the
+  // search-params string it was reported for, then derive `null` whenever
+  // the URL has moved on. This keeps invalidation as a render-time
+  // derivation instead of a setState-in-effect.
+  const [reportedCount, setReportedCount] = useState<{
+    qs: string;
+    total: number;
+  } | null>(null);
+  const currentQs = searchParams.toString();
+
+  // Track which router mode (push vs replace) the next URL update should use.
+  // Default `replace` for chip toggles + search typing — we don't want every
+  // keystroke to land in browser history. The mobile sheet's "Apply" flips
+  // this once via `applyMobileStaged`.
+  const pushNextRef = useRef(false);
+
+  const writeQuery = useCallback(
+    (next: LibraryQuery) => {
+      const qs = serializeLibraryQuery(next).toString();
+      const target = `/library${qs ? `?${qs}` : ""}`;
+      const usePush = pushNextRef.current;
+      pushNextRef.current = false;
+      startTransition(() => {
+        if (usePush) router.push(target);
+        else router.replace(target);
+      });
+    },
+    [router]
+  );
+
+  const setQuery = useCallback(
+    (patch: Partial<LibraryQuery>) => {
+      // Merge against the *current* parsed URL (not a stale closure).
+      const current = parseLibraryQuery(
+        new URLSearchParams(window.location.search)
+      );
+      const next: LibraryQuery = { ...current, ...patch };
+      writeQuery(next);
+    },
+    [writeQuery]
+  );
+
+  const toggleTag = useCallback(
+    (tagId: string) => {
+      const current = parseLibraryQuery(
+        new URLSearchParams(window.location.search)
+      );
+      const has = current.tags.includes(tagId);
+      const tags = has
+        ? current.tags.filter((t) => t !== tagId)
+        : [...current.tags, tagId];
+      writeQuery({ ...current, tags });
+    },
+    [writeQuery]
+  );
+
+  const clearAll = useCallback(() => {
+    writeQuery(EMPTY_QUERY);
+  }, [writeQuery]);
+
+  const activeCount = useMemo(() => countActive(query), [query]);
+
+  // Derived: the reported count is only valid for the URL it was reported
+  // for. After the URL moves on, render `null` until the next fetch lands.
+  const resultsCount =
+    reportedCount && reportedCount.qs === currentQs
+      ? reportedCount.total
+      : null;
+
+  const setResultsCount = useCallback((n: number | null) => {
+    if (n === null) {
+      setReportedCount(null);
+      return;
+    }
+    // Pin to the URL string at the time of report so a stale fetch landing
+    // after a filter change doesn't blip the wrong number into the summary.
+    const qs =
+      typeof window === "undefined"
+        ? ""
+        : new URLSearchParams(window.location.search).toString();
+    setReportedCount({ qs, total: n });
+  }, []);
+
+  const value = useMemo<LibraryQueryContextValue>(
+    () => ({
+      query,
+      setQuery,
+      toggleTag,
+      clearAll,
+      resultsCount,
+      setResultsCount,
+      isPending,
+      activeCount,
+    }),
+    [
+      query,
+      setQuery,
+      toggleTag,
+      clearAll,
+      resultsCount,
+      setResultsCount,
+      isPending,
+      activeCount,
+    ]
+  );
+
+  return (
+    <LibraryQueryContext.Provider value={value}>
+      {children}
+    </LibraryQueryContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Memory-backed provider for tests + the mobile sheet's staged state.
+// ---------------------------------------------------------------------------
+
+export function MemoryLibraryQueryProvider({
+  initial = EMPTY_QUERY,
+  children,
+}: {
+  initial?: LibraryQuery;
+  children: ReactNode;
+}) {
+  const [query, setQueryState] = useState<LibraryQuery>(initial);
+  const [resultsCount, setResultsCount] = useState<number | null>(null);
+
+  const setQuery = useCallback((patch: Partial<LibraryQuery>) => {
+    setQueryState((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const toggleTag = useCallback((tagId: string) => {
+    setQueryState((prev) => {
+      const has = prev.tags.includes(tagId);
+      return {
+        ...prev,
+        tags: has ? prev.tags.filter((t) => t !== tagId) : [...prev.tags, tagId],
+      };
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setQueryState(EMPTY_QUERY);
+  }, []);
+
+  const activeCount = useMemo(() => countActive(query), [query]);
+
+  const value = useMemo<LibraryQueryContextValue>(
+    () => ({
+      query,
+      setQuery,
+      toggleTag,
+      clearAll,
+      resultsCount,
+      setResultsCount,
+      isPending: false,
+      activeCount,
+    }),
+    [query, setQuery, toggleTag, clearAll, resultsCount, activeCount]
+  );
+
+  return (
+    <LibraryQueryContext.Provider value={value}>
+      {children}
+    </LibraryQueryContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for tests + filter-bar consumers)
+// ---------------------------------------------------------------------------
+
+export const EMPTY_LIBRARY_QUERY = EMPTY_QUERY;

--- a/src/app/(dashboard)/references/page.tsx
+++ b/src/app/(dashboard)/references/page.tsx
@@ -1,15 +1,34 @@
-import { ReferencesClient } from "./references-client";
+/**
+ * Legacy `/references` page → permanent redirect to `/library` (US1 / T020).
+ *
+ * Spec FR-007 calls for a 301; Next.js's App Router `redirect()` defaults to
+ * 307 (temporary). `permanentRedirect()` emits 308 (permanent), which is
+ * 301's modern semantic equivalent — preserves method + body across the
+ * redirect, which the bare-GET use-case here doesn't need but costs nothing.
+ *
+ * Query params are preserved verbatim so deep links and bookmarks keep
+ * working. The directory and the `/api/references*` proxy routes (T021) are
+ * intentionally left in place for the compat-shim window; Phase 6 (T045)
+ * removes them.
+ */
 
-export default function ReferencesPage() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">References</h1>
-        <p className="text-muted-foreground mt-1">
-          Browse and manage your uploaded reference images.
-        </p>
-      </div>
-      <ReferencesClient />
-    </div>
-  );
+import { permanentRedirect } from "next/navigation";
+
+export default async function ReferencesRedirectPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) qs.append(key, v);
+    } else {
+      qs.set(key, value);
+    }
+  }
+  const search = qs.toString();
+  permanentRedirect(search ? `/library?${search}` : "/library");
 }

--- a/src/app/api/assets/[id]/fork/route.ts
+++ b/src/app/api/assets/[id]/fork/route.ts
@@ -71,7 +71,11 @@ export async function POST(
       brandId: source.brandId,
       parentAssetId: source.id,
       status: "draft",
-      source: "fork",
+      // Library/DAM unification (0016): the source vocabulary is now
+      // uploaded | generated | imported. Forks are derivative generations,
+      // so they inherit `generated`. Lineage is still captured by
+      // parentAssetId; the fork API/UI continues to discriminate via that.
+      source: "generated",
       brandKitOverridden: false,
       mediaType: source.mediaType,
       model: source.model,

--- a/src/app/api/brands/[id]/route.ts
+++ b/src/app/api/brands/[id]/route.ts
@@ -24,6 +24,10 @@ const updateSchema = z.object({
   bannedTerms: z.array(z.string().min(1).max(64)).max(64).optional(),
   defaultLoraId: z.string().nullable().optional(),
   defaultLoraIds: z.array(z.string()).max(16).optional(),
+  // Renamed from `anchorReferenceIds` in the Library/DAM unification (0016).
+  // The frontend's brand-kit editor switches over in Phase 3; for now both
+  // names are accepted on PATCH so an in-flight UI deploy doesn't lose data.
+  anchorAssetIds: z.array(z.string().uuid()).max(16).optional(),
   anchorReferenceIds: z.array(z.string().uuid()).max(16).optional(),
   palette: z.array(z.string().regex(HEX)).max(16).optional(),
   selfApprovalAllowed: z.boolean().optional(),
@@ -81,10 +85,19 @@ export async function PATCH(
     return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
   }
 
+  // Compat shim: accept the legacy `anchorReferenceIds` name and fold it into
+  // the new `anchorAssetIds` column. Explicit `anchorAssetIds` wins if both
+  // are present. Removed once the Phase 3 UI lands and the legacy name dies.
+  const { anchorReferenceIds: legacyAnchors, ...rest } = parsed.data;
+  const updateValues: typeof rest & { anchorAssetIds?: string[] } = { ...rest };
+  if (legacyAnchors !== undefined && updateValues.anchorAssetIds === undefined) {
+    updateValues.anchorAssetIds = legacyAnchors;
+  }
+
   try {
     const [updated] = await db
       .update(brands)
-      .set(parsed.data)
+      .set(updateValues)
       .where(eq(brands.id, id))
       .returning();
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/src/app/api/generate/[id]/status/route.ts
+++ b/src/app/api/generate/[id]/status/route.ts
@@ -149,7 +149,7 @@ export async function GET(
           userId: session.user.id,
           brandId,
           status: "draft",
-          source: "generation",
+          source: "generated",
           brandKitOverridden: stashedOverride,
           mediaType: "video",
           model: generation.model,

--- a/src/app/api/generate/edit/route.ts
+++ b/src/app/api/generate/edit/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest) {
         userId,
         brandId,
         status: "draft",
-        source: "generation",
+        source: "generated",
         mediaType: "image",
         model: "grok-imagine" as ModelId,
         provider,

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -438,7 +438,7 @@ export async function POST(req: NextRequest) {
         userId,
         brandId,
         status: "draft",
-        source: "generation",
+        source: "generated",
         brandKitOverridden: kitResult.brandKitOverridden,
         mediaType: "image",
         model,

--- a/src/app/api/library/[id]/route.ts
+++ b/src/app/api/library/[id]/route.ts
@@ -1,0 +1,287 @@
+/**
+ * /api/library/[id] — single Library asset operations (US1 / T012-T014).
+ *
+ * GET    — detail view. Same item shape as the list endpoint.
+ * PATCH  — edit `tags` (M2M replace), `campaigns` (M2M replace), `fileName`
+ *          (column update), `pinnedToBrand` (toggle membership in
+ *          `brands.anchor_asset_ids` JSONB).
+ * DELETE — remove the asset row, R2 blob, thumbnail, AND scrub the asset id
+ *          from any brand's `anchor_asset_ids` JSONB (we don't have an FK
+ *          enforcing referential integrity over JSONB).
+ *
+ * All operations require the asset belong to the authenticated user. Mirrors
+ * the auth pattern of `/api/references/[id]` so the compat shim is a thin
+ * pass-through.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  assets,
+  assetCampaigns,
+  assetTags,
+  brands,
+  campaigns as campaignsTbl,
+} from "@/lib/db/schema";
+import { deleteFile } from "@/lib/storage";
+import { env } from "@/lib/env";
+import {
+  canEditBrandKit,
+  loadBrandContext,
+  loadRoleContext,
+} from "@/lib/workspace/permissions";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+import { loadOwnedLibraryItem } from "../lib";
+
+function flagOff(): NextResponse {
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
+
+// ---------------------------------------------------------------------------
+// GET — detail
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!env.LIBRARY_DAM_ENABLED) return flagOff();
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const item = await loadOwnedLibraryItem(id, session.user.id);
+  if (!item) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ item });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH — edit tags / campaigns / fileName / brand-anchor toggle
+// ---------------------------------------------------------------------------
+
+const patchSchema = z
+  .object({
+    tags: z.array(z.string().min(1).max(100)).max(64).optional(),
+    campaigns: z.array(z.string().uuid()).max(32).optional(),
+    fileName: z.string().min(1).max(512).nullable().optional(),
+    pinnedToBrand: z
+      .object({
+        brandId: z.string().uuid(),
+        pinned: z.boolean(),
+      })
+      .optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!env.LIBRARY_DAM_ENABLED) return flagOff();
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const { id } = await params;
+
+  // Auth + existence: same query, single round-trip.
+  const [existing] = await db
+    .select({ id: assets.id, userId: assets.userId })
+    .from(assets)
+    .where(eq(assets.id, id))
+    .limit(1);
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (existing.userId !== userId) {
+    // Don't leak existence cross-user — 404 mirrors the references behavior.
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { tags, campaigns, fileName, pinnedToBrand } = parsed.data;
+
+  // 1. tags — full replace. M2M is `(assetId, tag)` text strings, no Tag table.
+  if (tags !== undefined) {
+    await db.delete(assetTags).where(eq(assetTags.assetId, id));
+    if (tags.length > 0) {
+      // Dedupe — composite PK forbids dupes and a single payload typo would
+      // otherwise tank the entire patch.
+      const unique = Array.from(new Set(tags));
+      await db
+        .insert(assetTags)
+        .values(unique.map((tag) => ({ assetId: id, tag })));
+    }
+  }
+
+  // 2. campaigns — full replace. Validate every id belongs to a campaign the
+  // user can plausibly tag (we scope by campaigns linked to brands the user
+  // owns or is a member of, but the simpler v1 check is "the campaign exists"
+  // — campaign visibility is already brand-scoped at the API layer).
+  if (campaigns !== undefined) {
+    if (campaigns.length > 0) {
+      const validCampaigns = await db
+        .select({ id: campaignsTbl.id })
+        .from(campaignsTbl)
+        .where(inArray(campaignsTbl.id, campaigns));
+      if (validCampaigns.length !== campaigns.length) {
+        return NextResponse.json(
+          { error: "invalid_campaign_id" },
+          { status: 400 }
+        );
+      }
+    }
+    await db.delete(assetCampaigns).where(eq(assetCampaigns.assetId, id));
+    if (campaigns.length > 0) {
+      await db
+        .insert(assetCampaigns)
+        .values(
+          Array.from(new Set(campaigns)).map((campaignId) => ({
+            assetId: id,
+            campaignId,
+          }))
+        );
+    }
+  }
+
+  // 3. fileName — direct column update. `null` clears it.
+  if (fileName !== undefined) {
+    await db
+      .update(assets)
+      .set({ fileName, updatedAt: new Date() })
+      .where(eq(assets.id, id));
+  }
+
+  // 4. pinnedToBrand — toggle membership in brands.anchor_asset_ids JSONB.
+  // Validate the user owns / can edit the target brand. Owners of a Personal
+  // brand or workspace admins of the brand's workspace are the supported
+  // cases; we reuse the same `loadBrandContext` + `loadRoleContext` pair as
+  // the brand-kit editor (`/api/brands/[id]` PATCH) for consistency.
+  if (pinnedToBrand) {
+    const { brandId, pinned } = pinnedToBrand;
+
+    const brandCtx = await loadBrandContext(brandId);
+    if (!brandCtx) {
+      return NextResponse.json({ error: "brand_not_found" }, { status: 404 });
+    }
+    const ctx = await loadRoleContext(userId, brandCtx.workspaceId);
+    if (!canEditBrandKit(ctx, brandCtx)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Atomic JSONB rewrite — read the current array, dedupe, write back. A
+    // CAS-style concurrent edit could race; the brand kit UI is single-user
+    // and the dedupe makes a duplicate-write a no-op, so we accept the
+    // simpler shape over a row-lock dance.
+    const [brand] = await db
+      .select({ anchorAssetIds: brands.anchorAssetIds })
+      .from(brands)
+      .where(eq(brands.id, brandId))
+      .limit(1);
+    if (!brand) {
+      return NextResponse.json({ error: "brand_not_found" }, { status: 404 });
+    }
+    const current = brand.anchorAssetIds ?? [];
+    const next = pinned
+      ? Array.from(new Set([...current, id]))
+      : current.filter((x) => x !== id);
+    if (next.length !== current.length || pinned) {
+      await db
+        .update(brands)
+        .set({ anchorAssetIds: next })
+        .where(eq(brands.id, brandId));
+    }
+  }
+
+  // Return the freshly-hydrated item so the client doesn't need a follow-up GET.
+  const item = await loadOwnedLibraryItem(id, userId);
+  return NextResponse.json({ item });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — remove asset, blob, thumbnail, and scrub any brand-anchor pointers.
+// ---------------------------------------------------------------------------
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  if (!env.LIBRARY_DAM_ENABLED) return flagOff();
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const [asset] = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+    })
+    .from(assets)
+    .where(and(eq(assets.id, id), eq(assets.userId, session.user.id)))
+    .limit(1);
+
+  if (!asset) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Scrub the asset id from any brand's anchor_asset_ids JSONB array. The
+  // column has no FK to assets — Phase 2's plan called this out — so deletes
+  // would otherwise leave dangling pointers visible in the brand-kit UI.
+  // `jsonb_path_query_array` filters the array element-wise; cheaper than
+  // round-tripping every brand row through Node.
+  await db.execute(sql`
+    UPDATE "brands"
+    SET "anchor_asset_ids" = COALESCE(
+      (
+        SELECT jsonb_agg(elem)
+        FROM jsonb_array_elements_text("anchor_asset_ids") AS elem
+        WHERE elem <> ${id}
+      ),
+      '[]'::jsonb
+    )
+    WHERE "anchor_asset_ids" @> ${JSON.stringify([id])}::jsonb
+  `);
+
+  // Storage cleanup. Best-effort — orphan R2 objects are recoverable, a
+  // failed delete blocking the row would not be.
+  try {
+    await deleteFile(asset.r2Key);
+    if (asset.thumbnailR2Key) {
+      await deleteFile(asset.thumbnailR2Key);
+    }
+  } catch (error) {
+    console.error("Failed to delete library asset from storage:", error);
+  }
+
+  // Cascading FK on asset_tags / asset_campaigns / uploads / asset_review_log
+  // handles the rest.
+  await db.delete(assets).where(eq(assets.id, id));
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/library/lib.ts
+++ b/src/app/api/library/lib.ts
@@ -1,0 +1,182 @@
+/**
+ * Shared helpers for the Library API surface (T011/T012/T013).
+ *
+ * Hydrating an asset row into the public `LibraryItem` shape involves a
+ * left-join on `uploads` (for `mimeType`), two follow-up SELECTs for
+ * `assetTags` and `assetCampaigns`, and an R2-key → signed-URL resolve. Same
+ * mechanics for the list and the detail routes; centralizing it here keeps
+ * the contract identical and makes the `/api/references` compat shim
+ * trivially correct (it just calls our handlers).
+ */
+
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  assets,
+  assetCampaigns,
+  assetTags,
+  campaigns as campaignsTbl,
+  uploads,
+} from "@/lib/db/schema";
+import { getAssetUrl } from "@/lib/storage";
+
+export interface LibraryItem {
+  id: string;
+  userId: string;
+  brandId: string | null;
+  url: string;
+  thumbnailUrl: string;
+  fileName: string | null;
+  fileSize: number | null;
+  width: number | null;
+  height: number | null;
+  mimeType: string | null;
+  usageCount: number;
+  source: "uploaded" | "generated" | "imported";
+  tags: string[];
+  campaigns: string[];
+  embeddedAt: string | null;
+  createdAt: string;
+}
+
+export interface AssetJoinRow {
+  id: string;
+  userId: string;
+  brandId: string | null;
+  r2Key: string;
+  thumbnailR2Key: string | null;
+  fileName: string | null;
+  fileSize: number | null;
+  width: number | null;
+  height: number | null;
+  usageCount: number;
+  source: "uploaded" | "generated" | "imported";
+  embeddedAt: Date | null;
+  createdAt: Date;
+  mediaType: "image" | "video";
+  uploadContentType: string | null;
+}
+
+/**
+ * Fan out the per-asset tag and campaign lookups in a single round-trip per
+ * relation, then key them by assetId for O(1) merges.
+ */
+export async function loadTagsAndCampaigns(
+  assetIds: string[]
+): Promise<{ tags: Map<string, string[]>; campaigns: Map<string, string[]> }> {
+  if (assetIds.length === 0) {
+    return { tags: new Map(), campaigns: new Map() };
+  }
+
+  const [tagRows, campaignRows] = await Promise.all([
+    db
+      .select({ assetId: assetTags.assetId, tag: assetTags.tag })
+      .from(assetTags)
+      .where(inArray(assetTags.assetId, assetIds)),
+    db
+      .select({
+        assetId: assetCampaigns.assetId,
+        campaignName: campaignsTbl.name,
+      })
+      .from(assetCampaigns)
+      .innerJoin(campaignsTbl, eq(campaignsTbl.id, assetCampaigns.campaignId))
+      .where(inArray(assetCampaigns.assetId, assetIds)),
+  ]);
+
+  const tags = new Map<string, string[]>();
+  for (const r of tagRows) {
+    const list = tags.get(r.assetId) ?? [];
+    list.push(r.tag);
+    tags.set(r.assetId, list);
+  }
+
+  const campaigns = new Map<string, string[]>();
+  for (const r of campaignRows) {
+    const list = campaigns.get(r.assetId) ?? [];
+    list.push(r.campaignName);
+    campaigns.set(r.assetId, list);
+  }
+
+  return { tags, campaigns };
+}
+
+/** Convert a DB row + tag/campaign maps into the public Library item shape. */
+export async function hydrateLibraryItem(
+  row: AssetJoinRow,
+  tags: string[],
+  campaigns: string[]
+): Promise<LibraryItem> {
+  const url = await getAssetUrl(row.r2Key);
+  const thumbnailUrl = row.thumbnailR2Key
+    ? await getAssetUrl(row.thumbnailR2Key)
+    : null;
+
+  // Legacy references always carried `mimeType`. For migrated and newly-
+  // uploaded assets the paired `uploads.contentType` carries it; for
+  // generations we don't track upstream MIME — fall back to a sensible value
+  // derived from `mediaType` so the picker keeps rendering.
+  const mimeType =
+    row.uploadContentType ??
+    (row.mediaType === "video" ? "video/mp4" : "image/png");
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    brandId: row.brandId,
+    url,
+    thumbnailUrl: thumbnailUrl ?? url,
+    fileName: row.fileName,
+    fileSize: row.fileSize,
+    width: row.width,
+    height: row.height,
+    mimeType,
+    usageCount: row.usageCount,
+    source: row.source,
+    tags,
+    campaigns,
+    embeddedAt: row.embeddedAt ? row.embeddedAt.toISOString() : null,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Fetch a single asset scoped to `userId` and hydrate it. Returns `null` when
+ * the row doesn't exist or doesn't belong to the user — the caller turns that
+ * into the right HTTP status (404 for both — we don't leak existence).
+ */
+export async function loadOwnedLibraryItem(
+  assetId: string,
+  userId: string
+): Promise<LibraryItem | null> {
+  const [row] = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      fileName: assets.fileName,
+      fileSize: assets.fileSize,
+      width: assets.width,
+      height: assets.height,
+      usageCount: assets.usageCount,
+      source: assets.source,
+      embeddedAt: assets.embeddedAt,
+      createdAt: assets.createdAt,
+      mediaType: assets.mediaType,
+      uploadContentType: uploads.contentType,
+    })
+    .from(assets)
+    .leftJoin(uploads, eq(uploads.assetId, assets.id))
+    .where(and(eq(assets.id, assetId), eq(assets.userId, userId)))
+    .limit(1);
+
+  if (!row) return null;
+
+  const { tags, campaigns } = await loadTagsAndCampaigns([row.id]);
+  return hydrateLibraryItem(
+    row,
+    tags.get(row.id) ?? [],
+    campaigns.get(row.id) ?? []
+  );
+}

--- a/src/app/api/library/lib.ts
+++ b/src/app/api/library/lib.ts
@@ -17,8 +17,16 @@ import {
   assetTags,
   campaigns as campaignsTbl,
   uploads,
+  users,
 } from "@/lib/db/schema";
 import { getAssetUrl } from "@/lib/storage";
+
+export type AssetStatus =
+  | "draft"
+  | "in_review"
+  | "approved"
+  | "rejected"
+  | "archived";
 
 export interface LibraryItem {
   id: string;
@@ -33,6 +41,13 @@ export interface LibraryItem {
   mimeType: string | null;
   usageCount: number;
   source: "uploaded" | "generated" | "imported";
+  status: AssetStatus;
+  creator: {
+    id: string;
+    name: string | null;
+    image: string | null;
+    email: string | null;
+  } | null;
   tags: string[];
   campaigns: string[];
   embeddedAt: string | null;
@@ -51,10 +66,15 @@ export interface AssetJoinRow {
   height: number | null;
   usageCount: number;
   source: "uploaded" | "generated" | "imported";
+  status: AssetStatus;
   embeddedAt: Date | null;
   createdAt: Date;
   mediaType: "image" | "video";
   uploadContentType: string | null;
+  creatorId: string | null;
+  creatorName: string | null;
+  creatorImage: string | null;
+  creatorEmail: string | null;
 }
 
 /**
@@ -132,6 +152,15 @@ export async function hydrateLibraryItem(
     mimeType,
     usageCount: row.usageCount,
     source: row.source,
+    status: row.status,
+    creator: row.creatorId
+      ? {
+          id: row.creatorId,
+          name: row.creatorName,
+          image: row.creatorImage,
+          email: row.creatorEmail,
+        }
+      : null,
     tags,
     campaigns,
     embeddedAt: row.embeddedAt ? row.embeddedAt.toISOString() : null,
@@ -161,13 +190,19 @@ export async function loadOwnedLibraryItem(
       height: assets.height,
       usageCount: assets.usageCount,
       source: assets.source,
+      status: assets.status,
       embeddedAt: assets.embeddedAt,
       createdAt: assets.createdAt,
       mediaType: assets.mediaType,
       uploadContentType: uploads.contentType,
+      creatorId: users.id,
+      creatorName: users.name,
+      creatorImage: users.image,
+      creatorEmail: users.email,
     })
     .from(assets)
     .leftJoin(uploads, eq(uploads.assetId, assets.id))
+    .leftJoin(users, eq(users.id, assets.userId))
     .where(and(eq(assets.id, assetId), eq(assets.userId, userId)))
     .limit(1);
 

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /api/library — unified Library list endpoint (US1 / T011).
+ *
+ * Returns the current user's assets across every `source` value (uploaded,
+ * generated, imported), ordered by `(createdAt desc, id desc)` and paginated
+ * with a composite cursor so ties on `createdAt` (sub-millisecond inserts)
+ * never duplicate or skip rows.
+ *
+ * The item shape is a deliberate SUPERSET of the legacy `/api/references` GET
+ * item: every field the references-client and generate-client image-input
+ * picker consume (`url`, `thumbnailUrl`, `fileName`, `fileSize`, `width`,
+ * `height`, `mimeType`, `usageCount`, `createdAt`) is preserved 1:1, and the
+ * library-only fields (`source`, `tags`, `campaigns`, `embeddedAt`, `brandId`)
+ * are appended. The `/api/references` compat shim (T021) rewraps `items` →
+ * `references` so the shape match is total.
+ *
+ * Behind the `LIBRARY_DAM_ENABLED` flag — returns 404 when off so the new
+ * surface lands dark per the spec's "compat-shim window" approach.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { assets, uploads } from "@/lib/db/schema";
+import { env } from "@/lib/env";
+import { and, desc, eq, lt, or } from "drizzle-orm";
+import {
+  type LibraryItem,
+  hydrateLibraryItem,
+  loadTagsAndCampaigns,
+} from "./lib";
+
+export type { LibraryItem };
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+// Composite cursor: `<isoCreatedAt>__<uuid>`. Lexicographic on (createdAt, id)
+// matching the index `assets_user_id_created_at_idx` plus the id tiebreaker.
+function encodeCursor(createdAt: Date, id: string): string {
+  return `${createdAt.toISOString()}__${id}`;
+}
+
+function decodeCursor(raw: string | null): { createdAt: Date; id: string } | null {
+  if (!raw) return null;
+  const sep = raw.lastIndexOf("__");
+  if (sep < 0) return null;
+  const ts = raw.slice(0, sep);
+  const id = raw.slice(sep + 2);
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime()) || !id) return null;
+  return { createdAt: date, id };
+}
+
+export async function GET(req: NextRequest) {
+  if (!env.LIBRARY_DAM_ENABLED) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const cursor = decodeCursor(searchParams.get("cursor"));
+  const limitParam = parseInt(searchParams.get("limit") ?? `${DEFAULT_LIMIT}`, 10);
+  const limit = Math.min(
+    Math.max(Number.isFinite(limitParam) ? limitParam : DEFAULT_LIMIT, 1),
+    MAX_LIMIT
+  );
+  const brandIdFilter = searchParams.get("brandId");
+  const sourceFilter = searchParams.get("source");
+
+  const conditions = [eq(assets.userId, session.user.id)];
+
+  if (cursor) {
+    // (createdAt, id) lexicographic: rows where createdAt < cursor.createdAt,
+    // OR createdAt == cursor.createdAt AND id < cursor.id.
+    conditions.push(
+      or(
+        lt(assets.createdAt, cursor.createdAt),
+        and(eq(assets.createdAt, cursor.createdAt), lt(assets.id, cursor.id))
+      )!
+    );
+  }
+
+  if (brandIdFilter) {
+    conditions.push(eq(assets.brandId, brandIdFilter));
+  }
+
+  if (
+    sourceFilter === "uploaded" ||
+    sourceFilter === "generated" ||
+    sourceFilter === "imported"
+  ) {
+    conditions.push(eq(assets.source, sourceFilter));
+  }
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      fileName: assets.fileName,
+      fileSize: assets.fileSize,
+      width: assets.width,
+      height: assets.height,
+      usageCount: assets.usageCount,
+      source: assets.source,
+      embeddedAt: assets.embeddedAt,
+      createdAt: assets.createdAt,
+      mediaType: assets.mediaType,
+      uploadContentType: uploads.contentType,
+    })
+    .from(assets)
+    .leftJoin(uploads, eq(uploads.assetId, assets.id))
+    .where(and(...conditions))
+    .orderBy(desc(assets.createdAt), desc(assets.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const trimmed = hasMore ? rows.slice(0, limit) : rows;
+
+  const { tags, campaigns } = await loadTagsAndCampaigns(
+    trimmed.map((r) => r.id)
+  );
+
+  const items: LibraryItem[] = await Promise.all(
+    trimmed.map((r) =>
+      hydrateLibraryItem(r, tags.get(r.id) ?? [], campaigns.get(r.id) ?? [])
+    )
+  );
+
+  const last = trimmed[trimmed.length - 1];
+  const nextCursor = hasMore && last ? encodeCursor(last.createdAt, last.id) : null;
+
+  return NextResponse.json({ items, nextCursor });
+}

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -37,6 +37,8 @@ import { sql } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { env } from "@/lib/env";
+import { getCurrentWorkspace } from "@/lib/workspace/context";
+import { loadRoleContext, isWorkspaceAdmin } from "@/lib/workspace/permissions";
 import {
   type LibraryItem,
   hydrateLibraryItem,
@@ -105,10 +107,15 @@ type ListRow = {
   height: number | null;
   usage_count: number;
   source: "uploaded" | "generated" | "imported";
+  status: "draft" | "in_review" | "approved" | "rejected" | "archived";
   embedded_at: Date | string | null;
   created_at: Date | string;
   media_type: "image" | "video";
   upload_content_type: string | null;
+  creator_id: string | null;
+  creator_name: string | null;
+  creator_image: string | null;
+  creator_email: string | null;
 };
 
 type ListRowWithCount = ListRow & { total_count: number; [k: string]: unknown };
@@ -136,6 +143,7 @@ function rowToJoin(r: ListRow): AssetJoinRow {
     height: r.height,
     usageCount: r.usage_count,
     source: r.source,
+    status: r.status,
     embeddedAt:
       r.embedded_at == null
         ? null
@@ -146,6 +154,10 @@ function rowToJoin(r: ListRow): AssetJoinRow {
       r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
     mediaType: r.media_type,
     uploadContentType: r.upload_content_type,
+    creatorId: r.creator_id,
+    creatorName: r.creator_name,
+    creatorImage: r.creator_image,
+    creatorEmail: r.creator_email,
   };
 }
 
@@ -191,11 +203,25 @@ export async function GET(req: NextRequest) {
   const safeCampaignId =
     campaignId && UUID_RE.test(campaignId) ? campaignId : null;
 
+  // Workspace + admin check. Admins see every asset in the workspace
+  // (matching the page's initial-render scope); members are bound to their
+  // own assets.
+  const workspace = await getCurrentWorkspace(userId);
+  const isAdmin = workspace
+    ? isWorkspaceAdmin(await loadRoleContext(userId, workspace.id))
+    : false;
+
   // Build the WHERE clause as a list of sql fragments. Final SQL is composed
   // by `sql.join(... AND ...)` — drizzle parameterizes each value, so even
   // values pulled directly from URL inputs are safe against injection.
   const where: ReturnType<typeof sql>[] = [];
-  where.push(sql`a.user_id = ${userId}`);
+  if (isAdmin && workspace) {
+    where.push(
+      sql`a.brand_id IN (SELECT id FROM brands WHERE workspace_id = ${workspace.id})`
+    );
+  } else {
+    where.push(sql`a.user_id = ${userId}`);
+  }
 
   if (safeBrandId) {
     where.push(sql`a.brand_id = ${safeBrandId}`);
@@ -279,11 +305,16 @@ export async function GET(req: NextRequest) {
       SELECT
         a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
         a.file_name, a.file_size, a.width, a.height, a.usage_count,
-        a.source, a.embedded_at, a.created_at, a.media_type,
+        a.source, a.status, a.embedded_at, a.created_at, a.media_type,
         u.content_type AS upload_content_type,
+        cu.id AS creator_id,
+        cu.name AS creator_name,
+        cu.image AS creator_image,
+        cu.email AS creator_email,
         COUNT(*) OVER() AS total_count
       FROM assets a
       LEFT JOIN uploads u ON u.asset_id = a.id
+      LEFT JOIN users cu ON cu.id = a.user_id
       WHERE ${whereClause}
         AND a.search_vector @@ websearch_to_tsquery('english', ${q})
       ORDER BY ts_rank(a.search_vector, websearch_to_tsquery('english', ${q})) DESC,
@@ -308,11 +339,16 @@ export async function GET(req: NextRequest) {
       SELECT
         a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
         a.file_name, a.file_size, a.width, a.height, a.usage_count,
-        a.source, a.embedded_at, a.created_at, a.media_type,
+        a.source, a.status, a.embedded_at, a.created_at, a.media_type,
         u.content_type AS upload_content_type,
+        cu.id AS creator_id,
+        cu.name AS creator_name,
+        cu.image AS creator_image,
+        cu.email AS creator_email,
         COUNT(*) OVER() AS total_count
       FROM assets a
       LEFT JOIN uploads u ON u.asset_id = a.id
+      LEFT JOIN users cu ON cu.id = a.user_id
       WHERE ${whereClause}
       ${cursorClause}
       ORDER BY a.created_at DESC, a.id DESC

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -1,39 +1,65 @@
 /**
- * GET /api/library — unified Library list endpoint (US1 / T011).
+ * GET /api/library — unified Library list endpoint (US1 / T011, US2 / T025).
  *
  * Returns the current user's assets across every `source` value (uploaded,
  * generated, imported), ordered by `(createdAt desc, id desc)` and paginated
  * with a composite cursor so ties on `createdAt` (sub-millisecond inserts)
  * never duplicate or skip rows.
  *
- * The item shape is a deliberate SUPERSET of the legacy `/api/references` GET
- * item: every field the references-client and generate-client image-input
- * picker consume (`url`, `thumbnailUrl`, `fileName`, `fileSize`, `width`,
- * `height`, `mimeType`, `usageCount`, `createdAt`) is preserved 1:1, and the
- * library-only fields (`source`, `tags`, `campaigns`, `embeddedAt`, `brandId`)
- * are appended. The `/api/references` compat shim (T021) rewraps `items` →
- * `references` so the shape match is total.
+ * Phase 4 (US2) extension — query parameters:
+ *   - `q`         — full-text search; ranked by `ts_rank(search_vector, query)`.
+ *                    Cursor pagination is replaced with offset (hard limit 200)
+ *                    when `q` is set since rank order isn't time-monotonic.
+ *   - `brand`     — single brand uuid.
+ *   - `campaign`  — single campaign uuid.
+ *   - `tag`       — repeatable; multi-tag.
+ *   - `tagOp`     — `or` (default) or `and`. AND uses HAVING count(distinct).
+ *   - `source`    — repeatable; one of uploaded/generated/imported.
+ *   - `status`    — repeatable; one of draft/in_review/approved/rejected/archived.
+ *   - `cursor`    — composite `<isoTs>__<uuid>` cursor (only used when no `q`).
+ *   - `limit`     — clamps 1..200, default 50.
+ *   - `mode`      — RESERVED for Phase 5 (semantic/hybrid). Ignored today.
+ *
+ * Response shape:
+ *   {
+ *     items:      LibraryItem[],
+ *     nextCursor: string | null,   // null when q is set or no more pages
+ *     total:      number,          // count of all rows matching the filter,
+ *                                  //   ignoring pagination
+ *   }
  *
  * Behind the `LIBRARY_DAM_ENABLED` flag — returns 404 when off so the new
  * surface lands dark per the spec's "compat-shim window" approach.
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { assets, uploads } from "@/lib/db/schema";
 import { env } from "@/lib/env";
-import { and, desc, eq, lt, or } from "drizzle-orm";
 import {
   type LibraryItem,
   hydrateLibraryItem,
   loadTagsAndCampaigns,
+  type AssetJoinRow,
 } from "./lib";
 
 export type { LibraryItem };
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+const FTS_HARD_LIMIT = 200;
+
+const VALID_SOURCES = new Set<"uploaded" | "generated" | "imported">([
+  "uploaded",
+  "generated",
+  "imported",
+]);
+const VALID_STATUSES = new Set<
+  "draft" | "in_review" | "approved" | "rejected" | "archived"
+>(["draft", "in_review", "approved", "rejected", "archived"]);
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Composite cursor: `<isoCreatedAt>__<uuid>`. Lexicographic on (createdAt, id)
 // matching the index `assets_user_id_created_at_idx` plus the id tiebreaker.
@@ -52,6 +78,77 @@ function decodeCursor(raw: string | null): { createdAt: Date; id: string } | nul
   return { createdAt: date, id };
 }
 
+function parseListFilter<T>(
+  values: string[],
+  whitelist: Set<T>
+): T[] {
+  const out: T[] = [];
+  const seen = new Set<T>();
+  for (const v of values) {
+    if (whitelist.has(v as T) && !seen.has(v as T)) {
+      seen.add(v as T);
+      out.push(v as T);
+    }
+  }
+  return out;
+}
+
+type ListRow = {
+  id: string;
+  user_id: string;
+  brand_id: string | null;
+  r2_key: string;
+  thumbnail_r2_key: string | null;
+  file_name: string | null;
+  file_size: number | null;
+  width: number | null;
+  height: number | null;
+  usage_count: number;
+  source: "uploaded" | "generated" | "imported";
+  embedded_at: Date | string | null;
+  created_at: Date | string;
+  media_type: "image" | "video";
+  upload_content_type: string | null;
+};
+
+type ListRowWithCount = ListRow & { total_count: number; [k: string]: unknown };
+
+function stripTotal(r: ListRowWithCount): ListRow {
+  // Drop the window-function-supplied total_count column from each row so the
+  // hydrator only sees the asset shape it expects.
+  const {
+    total_count: _t, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ...rest
+  } = r;
+  return rest as ListRow;
+}
+
+function rowToJoin(r: ListRow): AssetJoinRow {
+  return {
+    id: r.id,
+    userId: r.user_id,
+    brandId: r.brand_id,
+    r2Key: r.r2_key,
+    thumbnailR2Key: r.thumbnail_r2_key,
+    fileName: r.file_name,
+    fileSize: r.file_size,
+    width: r.width,
+    height: r.height,
+    usageCount: r.usage_count,
+    source: r.source,
+    embeddedAt:
+      r.embedded_at == null
+        ? null
+        : r.embedded_at instanceof Date
+        ? r.embedded_at
+        : new Date(r.embedded_at),
+    createdAt:
+      r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
+    mediaType: r.media_type,
+    uploadContentType: r.upload_content_type,
+  };
+}
+
 export async function GET(req: NextRequest) {
   if (!env.LIBRARY_DAM_ENABLED) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -61,6 +158,7 @@ export async function GET(req: NextRequest) {
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+  const userId = session.user.id;
 
   const { searchParams } = new URL(req.url);
   const cursor = decodeCursor(searchParams.get("cursor"));
@@ -69,73 +167,188 @@ export async function GET(req: NextRequest) {
     Math.max(Number.isFinite(limitParam) ? limitParam : DEFAULT_LIMIT, 1),
     MAX_LIMIT
   );
-  const brandIdFilter = searchParams.get("brandId");
-  const sourceFilter = searchParams.get("source");
 
-  const conditions = [eq(assets.userId, session.user.id)];
+  const brandId = searchParams.get("brand");
+  const campaignId = searchParams.get("campaign");
+  const tagOp = searchParams.get("tagOp") === "and" ? "and" : "or";
+  const tags = searchParams
+    .getAll("tag")
+    .filter((t) => t.length > 0 && t.length <= 100);
+  const sources = parseListFilter(
+    searchParams.getAll("source"),
+    VALID_SOURCES as Set<string>
+  ) as ("uploaded" | "generated" | "imported")[];
+  const statuses = parseListFilter(
+    searchParams.getAll("status"),
+    VALID_STATUSES as Set<string>
+  ) as ("draft" | "in_review" | "approved" | "rejected" | "archived")[];
+  const qRaw = searchParams.get("q");
+  const q = qRaw && qRaw.trim().length > 0 ? qRaw.trim() : null;
 
-  if (cursor) {
-    // (createdAt, id) lexicographic: rows where createdAt < cursor.createdAt,
-    // OR createdAt == cursor.createdAt AND id < cursor.id.
-    conditions.push(
-      or(
-        lt(assets.createdAt, cursor.createdAt),
-        and(eq(assets.createdAt, cursor.createdAt), lt(assets.id, cursor.id))
-      )!
+  // Defensive uuid validation — never let an unsanitized string near jsonb/uuid
+  // operators. Invalid → ignored, equivalent to "no filter".
+  const safeBrandId = brandId && UUID_RE.test(brandId) ? brandId : null;
+  const safeCampaignId =
+    campaignId && UUID_RE.test(campaignId) ? campaignId : null;
+
+  // Build the WHERE clause as a list of sql fragments. Final SQL is composed
+  // by `sql.join(... AND ...)` — drizzle parameterizes each value, so even
+  // values pulled directly from URL inputs are safe against injection.
+  const where: ReturnType<typeof sql>[] = [];
+  where.push(sql`a.user_id = ${userId}`);
+
+  if (safeBrandId) {
+    where.push(sql`a.brand_id = ${safeBrandId}`);
+  }
+  if (safeCampaignId) {
+    where.push(
+      sql`a.id IN (SELECT asset_id FROM asset_campaigns WHERE campaign_id = ${safeCampaignId})`
     );
   }
-
-  if (brandIdFilter) {
-    conditions.push(eq(assets.brandId, brandIdFilter));
+  if (sources.length > 0) {
+    where.push(
+      sql`a.source IN (${sql.join(
+        sources.map((s) => sql`${s}`),
+        sql`, `
+      )})`
+    );
+  }
+  if (statuses.length > 0) {
+    where.push(
+      sql`a.status IN (${sql.join(
+        statuses.map((s) => sql`${s}`),
+        sql`, `
+      )})`
+    );
+  }
+  if (tags.length > 0) {
+    if (tagOp === "and") {
+      // ALL of these tags — group by + having count.
+      where.push(
+        sql`a.id IN (
+          SELECT asset_id
+          FROM asset_tags
+          WHERE tag IN (${sql.join(
+            tags.map((t) => sql`${t}`),
+            sql`, `
+          )})
+          GROUP BY asset_id
+          HAVING COUNT(DISTINCT tag) = ${tags.length}
+        )`
+      );
+    } else {
+      where.push(
+        sql`a.id IN (
+          SELECT asset_id
+          FROM asset_tags
+          WHERE tag IN (${sql.join(
+            tags.map((t) => sql`${t}`),
+            sql`, `
+          )})
+        )`
+      );
+    }
   }
 
-  if (
-    sourceFilter === "uploaded" ||
-    sourceFilter === "generated" ||
-    sourceFilter === "imported"
-  ) {
-    conditions.push(eq(assets.source, sourceFilter));
+  const whereClause = sql.join(where, sql` AND `);
+
+  // -------------------------------------------------------------------------
+  // Total count — single window-function pass on the filtered set. Cheaper
+  // than a parallel COUNT(*) for the common case (user has < 1k rows). We
+  // alias as `total_count` and return it on the first item; if there are
+  // zero rows we run a cheap fallback COUNT.
+  // -------------------------------------------------------------------------
+
+  let nextCursor: string | null = null;
+  let rows: ListRow[] = [];
+  let total = 0;
+
+  if (q) {
+    // Full-text path. Order by ts_rank desc, fall back to created_at desc on
+    // ties. Offset paginates within the hard limit since rank order isn't
+    // time-monotonic. Frontend currently only requests page 1; future infinite
+    // scroll on FTS results would pass `cursor` as a numeric offset (kept
+    // simple here — FTS pagination beyond 200 hits is a Phase 5 problem).
+    const offset =
+      cursor && Number.isFinite(parseInt(cursor.id, 10))
+        ? Math.max(0, parseInt(cursor.id, 10))
+        : 0;
+    const effLimit = Math.min(limit, FTS_HARD_LIMIT);
+
+    const result = await db.execute<ListRowWithCount>(sql`
+      SELECT
+        a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
+        a.file_name, a.file_size, a.width, a.height, a.usage_count,
+        a.source, a.embedded_at, a.created_at, a.media_type,
+        u.content_type AS upload_content_type,
+        COUNT(*) OVER() AS total_count
+      FROM assets a
+      LEFT JOIN uploads u ON u.asset_id = a.id
+      WHERE ${whereClause}
+        AND a.search_vector @@ websearch_to_tsquery('english', ${q})
+      ORDER BY ts_rank(a.search_vector, websearch_to_tsquery('english', ${q})) DESC,
+               a.created_at DESC, a.id DESC
+      LIMIT ${effLimit}
+      OFFSET ${offset}
+    `);
+
+    const allRows = result.rows as Array<ListRow & { total_count: number }>;
+    rows = allRows.map((r) => stripTotal(r));
+    total = allRows.length > 0 ? Number(allRows[0].total_count) : 0;
+    // No more pages if we ran past hard limit — keep `nextCursor` null.
+    nextCursor = null;
+  } else {
+    // Cursor path. (createdAt, id) lexicographic descending.
+    const cursorClause = cursor
+      ? sql`AND (a.created_at < ${cursor.createdAt.toISOString()}::timestamptz
+              OR (a.created_at = ${cursor.createdAt.toISOString()}::timestamptz AND a.id < ${cursor.id}))`
+      : sql``;
+
+    const result = await db.execute<ListRowWithCount>(sql`
+      SELECT
+        a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
+        a.file_name, a.file_size, a.width, a.height, a.usage_count,
+        a.source, a.embedded_at, a.created_at, a.media_type,
+        u.content_type AS upload_content_type,
+        COUNT(*) OVER() AS total_count
+      FROM assets a
+      LEFT JOIN uploads u ON u.asset_id = a.id
+      WHERE ${whereClause}
+      ${cursorClause}
+      ORDER BY a.created_at DESC, a.id DESC
+      LIMIT ${limit + 1}
+    `);
+
+    const allRows = result.rows as Array<ListRow & { total_count: number }>;
+    total = allRows.length > 0 ? Number(allRows[0].total_count) : 0;
+    const hasMore = allRows.length > limit;
+    const trimmed = hasMore ? allRows.slice(0, limit) : allRows;
+    rows = trimmed.map((r) => stripTotal(r));
+
+    if (hasMore && trimmed.length > 0) {
+      const last = trimmed[trimmed.length - 1];
+      nextCursor = encodeCursor(
+        last.created_at instanceof Date
+          ? last.created_at
+          : new Date(last.created_at),
+        last.id
+      );
+    }
   }
 
-  const rows = await db
-    .select({
-      id: assets.id,
-      userId: assets.userId,
-      brandId: assets.brandId,
-      r2Key: assets.r2Key,
-      thumbnailR2Key: assets.thumbnailR2Key,
-      fileName: assets.fileName,
-      fileSize: assets.fileSize,
-      width: assets.width,
-      height: assets.height,
-      usageCount: assets.usageCount,
-      source: assets.source,
-      embeddedAt: assets.embeddedAt,
-      createdAt: assets.createdAt,
-      mediaType: assets.mediaType,
-      uploadContentType: uploads.contentType,
-    })
-    .from(assets)
-    .leftJoin(uploads, eq(uploads.assetId, assets.id))
-    .where(and(...conditions))
-    .orderBy(desc(assets.createdAt), desc(assets.id))
-    .limit(limit + 1);
+  // If the WHERE matched nothing, the window function emits zero rows — but
+  // we still want `total = 0` (already correct above).
 
-  const hasMore = rows.length > limit;
-  const trimmed = hasMore ? rows.slice(0, limit) : rows;
-
-  const { tags, campaigns } = await loadTagsAndCampaigns(
-    trimmed.map((r) => r.id)
+  const joinRows = rows.map(rowToJoin);
+  const { tags: tagMap, campaigns: campaignMap } = await loadTagsAndCampaigns(
+    joinRows.map((r) => r.id)
   );
 
   const items: LibraryItem[] = await Promise.all(
-    trimmed.map((r) =>
-      hydrateLibraryItem(r, tags.get(r.id) ?? [], campaigns.get(r.id) ?? [])
+    joinRows.map((r) =>
+      hydrateLibraryItem(r, tagMap.get(r.id) ?? [], campaignMap.get(r.id) ?? [])
     )
   );
 
-  const last = trimmed[trimmed.length - 1];
-  const nextCursor = hasMore && last ? encodeCursor(last.createdAt, last.id) : null;
-
-  return NextResponse.json({ items, nextCursor });
+  return NextResponse.json({ items, nextCursor, total });
 }

--- a/src/app/api/references/[id]/route.ts
+++ b/src/app/api/references/[id]/route.ts
@@ -1,47 +1,21 @@
-import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { references } from "@/lib/db/schema";
-import { deleteFile } from "@/lib/storage";
-import { eq, and } from "drizzle-orm";
+/**
+ * /api/references/[id] compat shim (US1 / T021).
+ *
+ * TODO(library-dam Phase 6 / T044): remove this proxy after the compat-shim
+ * release. Forwards to `/api/library/[id]`'s DELETE handler — the only
+ * verb the legacy references API exposed.
+ *
+ * GET/PATCH never existed on the references endpoint, so we don't proxy
+ * those — clients hitting them on this URL get 405 Method Not Allowed
+ * (Next.js's default for unimplemented verbs).
+ */
+
+import { NextRequest } from "next/server";
+import { DELETE as libraryDELETE } from "@/app/api/library/[id]/route";
 
 export async function DELETE(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
 ) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { id } = await params;
-
-  const [ref] = await db
-    .select({
-      id: references.id,
-      userId: references.userId,
-      r2Key: references.r2Key,
-      thumbnailR2Key: references.thumbnailR2Key,
-    })
-    .from(references)
-    .where(and(eq(references.id, id), eq(references.userId, session.user.id)))
-    .limit(1);
-
-  if (!ref) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-
-  // Delete from storage
-  try {
-    await deleteFile(ref.r2Key);
-    if (ref.thumbnailR2Key) {
-      await deleteFile(ref.thumbnailR2Key);
-    }
-  } catch (error) {
-    console.error("Failed to delete reference from storage:", error);
-  }
-
-  await db.delete(references).where(eq(references.id, id));
-
-  return NextResponse.json({ success: true });
+  return libraryDELETE(req, ctx);
 }

--- a/src/app/api/references/route.ts
+++ b/src/app/api/references/route.ts
@@ -1,62 +1,34 @@
+/**
+ * /api/references compat shim (US1 / T021).
+ *
+ * TODO(library-dam Phase 6 / T044): remove this proxy after the compat-shim
+ * release. The unified Library API at `/api/library` is the source of truth;
+ * this shim exists for one release so external bookmarks of `/api/references`
+ * (and any in-flight client deploy that hasn't picked up T022 yet) keep
+ * working.
+ *
+ * The library route returns `{ items, nextCursor }`; the legacy references
+ * client expects `{ references, nextCursor }` with a slightly narrower item
+ * shape (no `source`/`tags`/`campaigns`/`embeddedAt`/`brandId`). The library
+ * item shape is a SUPERSET of the references item shape, so we forward the
+ * request to the library handler and rename the array key in-place.
+ */
+
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { db } from "@/lib/db";
-import { references } from "@/lib/db/schema";
-import { getAssetUrl } from "@/lib/storage";
-import { eq, desc, and, lt } from "drizzle-orm";
+import { GET as libraryGET } from "@/app/api/library/route";
 
 export async function GET(req: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const upstream = await libraryGET(req);
 
-  const { searchParams } = new URL(req.url);
-  const cursor = searchParams.get("cursor");
-  const limit = Math.min(parseInt(searchParams.get("limit") ?? "30", 10), 100);
+  // 401 / 404 / 4xx — pass through verbatim.
+  if (!upstream.ok) return upstream;
 
-  const conditions = [eq(references.userId, session.user.id)];
-
-  if (cursor) {
-    conditions.push(lt(references.createdAt, new Date(cursor)));
-  }
-
-  const rows = await db
-    .select()
-    .from(references)
-    .where(and(...conditions))
-    .orderBy(desc(references.createdAt))
-    .limit(limit + 1);
-
-  const hasMore = rows.length > limit;
-  const refRows = hasMore ? rows.slice(0, limit) : rows;
-
-  const results = await Promise.all(
-    refRows.map(async (r) => {
-      const url = await getAssetUrl(r.r2Key);
-      const thumbnailUrl = r.thumbnailR2Key
-        ? await getAssetUrl(r.thumbnailR2Key)
-        : null;
-
-      return {
-        id: r.id,
-        userId: r.userId,
-        url,
-        thumbnailUrl: thumbnailUrl ?? url,
-        fileName: r.fileName,
-        fileSize: r.fileSize,
-        width: r.width,
-        height: r.height,
-        mimeType: r.mimeType,
-        usageCount: r.usageCount,
-        createdAt: r.createdAt,
-      };
-    })
-  );
-
-  const nextCursor = hasMore
-    ? refRows[refRows.length - 1].createdAt.toISOString()
-    : null;
-
-  return NextResponse.json({ references: results, nextCursor });
+  const data = (await upstream.json()) as {
+    items: unknown[];
+    nextCursor: string | null;
+  };
+  return NextResponse.json({
+    references: data.items,
+    nextCursor: data.nextCursor,
+  });
 }

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -6,25 +6,17 @@ import {
   getAssetUrl,
 } from "@/lib/storage";
 import { db } from "@/lib/db";
-import { assets, brands, references, uploads } from "@/lib/db/schema";
+import { assets, brands, uploads } from "@/lib/db/schema";
 import { getCurrentWorkspace } from "@/lib/workspace/context";
 import {
   canCreateAsset,
   loadBrandContext,
   loadRoleContext,
 } from "@/lib/workspace/permissions";
+import { resolvePersonalBrandId } from "@/lib/workspace/personal";
 import { nanoid } from "nanoid";
 import sharp from "sharp";
-import { and, eq } from "drizzle-orm";
-
-// Reference path (legacy) — for image inputs in /generate. 10MB images only.
-const REFERENCE_MAX_SIZE = 10 * 1024 * 1024;
-const REFERENCE_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/webp",
-  "image/gif",
-];
+import { eq } from "drizzle-orm";
 
 // Asset-upload validation contract lives in a sibling pure module so it can
 // be unit-tested without dragging in this route's `next/server` + DB graph.
@@ -54,6 +46,22 @@ const EXT_MAP: Record<string, string> = {
   "video/webm": "webm",
 };
 
+/**
+ * POST /api/uploads — single unified upload path post-Library/DAM cutover
+ * (T015 / FR-008). Every successful upload writes to `assets` with
+ * `source = 'uploaded'`, regardless of whether `brandId` was provided.
+ *
+ * - `brandId` (optional): named brand or the literal `"personal"` sentinel.
+ *   Absent → folded into the user's Personal brand (mirrors the Phase 2
+ *   backfill script: `brands.is_personal = true AND brands.owner_id = userId`).
+ * - Permissions: `canCreateAsset` gate on the resolved brand. Workspace admin
+ *   override applies; viewers are denied.
+ * - Response: a single shape that satisfies both consumers — the asset-
+ *   centric `upload-dropzone.tsx` (reads `data.asset`) AND the legacy
+ *   `generate-client.tsx` image-input flow (reads `data.url`). The latter
+ *   was previously served by the dropped `references` branch.
+ */
+
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -69,23 +77,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "no_file" }, { status: 400 });
   }
 
-  // The presence of `brandId` is the discriminator: brand-scoped uploads land
-  // in `assets` + `uploads`; the legacy reference path is unchanged.
-  if (brandIdHint) {
-    return handleAssetUpload(userId, file, brandIdHint);
-  }
-  return handleReferenceUpload(userId, file);
-}
-
-// ---------------------------------------------------------------------------
-// Asset upload (US6 / T120)
-// ---------------------------------------------------------------------------
-
-async function handleAssetUpload(
-  userId: string,
-  file: File,
-  brandIdHint: string
-) {
   const validation = validateAssetUpload(file);
   if (!validation.ok) {
     const body: Record<string, unknown> = { error: validation.error };
@@ -100,25 +91,21 @@ async function handleAssetUpload(
     return NextResponse.json({ error: "no_workspace" }, { status: 403 });
   }
 
-  // Resolve brand. Personal sentinel: pick the user's Personal brand in this
-  // workspace; explicit uuid: must belong to this workspace.
+  // Brand resolution. Three cases:
+  //   1. `personal` sentinel              → user's Personal brand in this workspace.
+  //   2. explicit brandId (uuid)          → must belong to this workspace.
+  //   3. absent                           → fold into the user's Personal brand
+  //                                        (mirrors the Phase 2 backfill).
   let brandId: string;
-  if (brandIdHint === "personal") {
-    const [personal] = await db
-      .select({ id: brands.id })
-      .from(brands)
-      .where(
-        and(
-          eq(brands.workspaceId, workspace.id),
-          eq(brands.isPersonal, true),
-          eq(brands.ownerId, userId)
-        )
-      )
-      .limit(1);
-    if (!personal) {
-      return NextResponse.json({ error: "personal_brand_missing" }, { status: 404 });
+  if (brandIdHint === "personal" || brandIdHint === null) {
+    const personalId = await resolvePersonalBrandId(userId, workspace.id);
+    if (!personalId) {
+      return NextResponse.json(
+        { error: "personal_brand_missing" },
+        { status: 404 }
+      );
     }
-    brandId = personal.id;
+    brandId = personalId;
   } else {
     const [b] = await db
       .select({ id: brands.id, workspaceId: brands.workspaceId })
@@ -194,6 +181,9 @@ async function handleAssetUpload(
       r2Key: key,
       r2Url: url,
       thumbnailR2Key: thumbnailKey,
+      // FR-004: uploads now retain their original filename in the new column.
+      fileName: file.name,
+      usageCount: 0,
       width,
       height,
       fileSize: file.size,
@@ -216,7 +206,14 @@ async function handleAssetUpload(
   const finalUrl = await getAssetUrl(key);
   const finalThumbnailUrl = thumbnailKey ? await getAssetUrl(thumbnailKey) : null;
 
+  // Single response shape that satisfies BOTH consumers:
+  //   - upload-dropzone.tsx          reads `data.asset`
+  //   - generate-client.tsx          reads `data.url` (legacy references shape)
+  // Future cleanup (Phase 6): once generate-client switches to `data.asset.url`
+  // we can drop the top-level `url`/`key` fields.
   return NextResponse.json({
+    url: finalUrl,
+    key,
     asset: {
       id: asset.id,
       brandId,
@@ -230,55 +227,4 @@ async function handleAssetUpload(
       createdAt: asset.createdAt,
     },
   });
-}
-
-// ---------------------------------------------------------------------------
-// Reference upload (legacy, used by /generate image-input)
-// ---------------------------------------------------------------------------
-
-async function handleReferenceUpload(userId: string, file: File) {
-  if (!REFERENCE_TYPES.includes(file.type)) {
-    return NextResponse.json(
-      { error: "Unsupported file type. Allowed: PNG, JPEG, WebP, GIF" },
-      { status: 400 }
-    );
-  }
-  if (file.size > REFERENCE_MAX_SIZE) {
-    return NextResponse.json(
-      { error: "File too large. Maximum size is 10 MB" },
-      { status: 400 }
-    );
-  }
-
-  const buffer = Buffer.from(await file.arrayBuffer());
-  const ext = EXT_MAP[file.type] ?? "png";
-  const key = `user-uploads/${userId}/${Date.now()}-${nanoid(10)}.${ext}`;
-
-  const url = await uploadFile(buffer, key, file.type);
-
-  const metadata = await sharp(buffer).metadata();
-
-  let thumbnailKey: string | undefined;
-  try {
-    thumbnailKey = await generateAndUploadThumbnail(buffer, key);
-  } catch {
-    // Non-critical — proceed without thumbnail
-  }
-
-  const [ref] = await db
-    .insert(references)
-    .values({
-      userId,
-      r2Key: key,
-      r2Url: url,
-      thumbnailR2Key: thumbnailKey,
-      fileName: file.name,
-      fileSize: file.size,
-      width: metadata.width ?? null,
-      height: metadata.height ?? null,
-      mimeType: file.type,
-    })
-    .returning({ id: references.id });
-
-  return NextResponse.json({ url, key, referenceId: ref.id });
 }

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -183,7 +183,7 @@ async function handleAssetUpload(
       userId,
       brandId,
       status: "draft",
-      source: "upload",
+      source: "uploaded",
       brandKitOverridden: false,
       mediaType: isImage ? "image" : "video",
       model: "upload",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -125,7 +125,7 @@ const topNavItems: NavItem[] = [
 // LIBRARY section — workspace-wide content surfaces.
 const libraryNavItems: NavItem[] = [
   { title: "Brews", href: "/brews", icon: FlaskConical },
-  { title: "References", href: "/references", icon: ImagePlus },
+  { title: "Library", href: "/library", icon: ImagePlus },
   { title: "LoRAs", href: "/loras", icon: Layers },
 ];
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,24 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-04-30",
+    title: "Library, upgraded for teams",
+    bullets: [
+      "Workspace admins now see every brand's assets in the Library — not just their own",
+      "Brand filter shows all the brands you have access to, with personal libraries labelled by member name and avatar so multiple Personals are easy to tell apart",
+      "Each thumbnail now shows a status chip (Draft, In review, Approved, Rejected, Archived) so you can scan workflow state without opening the asset",
+      "A creator avatar in the bottom-right of every card shows who uploaded or generated it — hover for their name and the action",
+    ],
+  },
+  {
+    date: "2026-04-30",
+    title: "Send feedback from Slack",
+    bullets: [
+      "Type /feedback in Slack to fire off a quick note, bug report, or Loom link straight to the team",
+      "A short form keeps your feedback in context — no copy-paste, no lost threads",
+    ],
+  },
+  {
     date: "2026-04-29",
     title: "Prompt enhancer, redesigned",
     bullets: [

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -11,7 +11,23 @@ import {
   primaryKey,
   index,
   uniqueIndex,
+  vector,
+  customType,
 } from "drizzle-orm/pg-core";
+
+// ============================================================
+// Postgres tsvector column. Drizzle has no first-class tsvector type, but the
+// generated `search_vector` column on `assets` (declared in migration 0016) is
+// read-only at the app layer — toDriver/fromDriver pass values through as
+// strings (the rare case where the app inspects them; most code only feeds
+// the GIN index via `searchVector @@ websearch_to_tsquery(...)`).
+// ============================================================
+
+const tsvector = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
 
 // ============================================================
 // Users
@@ -145,7 +161,10 @@ export const brands = pgTable(
       .$type<string[]>()
       .notNull()
       .default([]),
-    anchorReferenceIds: jsonb("anchor_reference_ids")
+    // Renamed from `anchor_reference_ids` in migration 0016 as part of the
+    // Library / DAM unification. JSONB shape unchanged — values are asset
+    // ids (post-backfill) instead of legacy reference ids.
+    anchorAssetIds: jsonb("anchor_asset_ids")
       .$type<string[]>()
       .notNull()
       .default([]),
@@ -253,9 +272,13 @@ export const assets = pgTable(
     })
       .notNull()
       .default("draft"),
-    source: text("source", { enum: ["generation", "upload", "fork"] })
+    // Library / DAM discriminator. Migration 0016 rewrote legacy values
+    // ("generation" → "generated", "upload" → "uploaded", "fork" → "generated"),
+    // landing on the unified vocabulary. Imports come in via the future
+    // import flow; the value is reserved here so consumers can switch on it.
+    source: text("source", { enum: ["uploaded", "generated", "imported"] })
       .notNull()
-      .default("generation"),
+      .default("generated"),
     brandKitOverridden: boolean("brand_kit_overridden")
       .notNull()
       .default(false),
@@ -271,6 +294,27 @@ export const assets = pgTable(
     r2Key: text("r2_key").notNull(),
     r2Url: text("r2_url").notNull(),
     thumbnailR2Key: text("thumbnail_r2_key"),
+    // Library/DAM additions (migration 0016).
+    // Original upload filename — uploads now retain this; generations may set
+    // a synthesized name. Nullable for legacy rows.
+    fileName: text("file_name"),
+    // Ported from references.usage_count — surfaces "recently used" affordances.
+    usageCount: integer("usage_count").notNull().default(0),
+    // CLIP-style embedding (768-dim, ViT-L/14). Populated asynchronously by
+    // the embed-assets worker; nullable until the cron picks the row up.
+    embedding: vector("embedding", { dimensions: 768 }),
+    embeddingModel: text("embedding_model"),
+    embeddedAt: timestamp("embedded_at", { withTimezone: true, mode: "date" }),
+    // Denormalized tag-name string maintained by triggers on `asset_tags` —
+    // feeds the generated search_vector below. Read-only at the app layer.
+    tagsText: text("tags_text").notNull().default(""),
+    // Generated tsvector column over file_name + prompt + tags_text.
+    // Backed by a GIN index for fast `@@ websearch_to_tsquery(...)`.
+    searchVector: tsvector("search_vector"),
+    // TEMPORARY pointer to the legacy references.id for rows backfilled by
+    // scripts/migrate-references-to-assets.ts. Dropped at cutover (Phase 6 /
+    // T043) once the compat-shim release ships clean.
+    legacyReferenceId: uuid("legacy_reference_id"),
     width: integer("width"),
     height: integer("height"),
     fileSize: integer("file_size"),
@@ -289,6 +333,16 @@ export const assets = pgTable(
     index("assets_model_idx").on(table.model),
     index("assets_media_type_idx").on(table.mediaType),
     index("assets_created_at_idx").on(table.createdAt),
+    // Library/DAM indexes (migration 0016).
+    index("assets_user_id_created_at_idx").on(table.userId, table.createdAt),
+    index("assets_source_idx").on(table.source),
+    // Note: GIN on searchVector and HNSW on embedding are declared in the
+    // SQL migration; drizzle-kit's index helper doesn't model HNSW with
+    // operator classes nor GIN over a generated tsvector cleanly enough to
+    // round-trip here. The runtime queries use raw SQL anyway.
+    uniqueIndex("assets_legacy_reference_id_uniq")
+      .on(table.legacyReferenceId)
+      .where(sql`${table.legacyReferenceId} IS NOT NULL`),
   ]
 );
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,6 +14,14 @@ const envSchema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
+  // Library/DAM unification — when off, /library and /api/library 404 and the
+  // sidebar still points at /references. Flip to "true" once the unified
+  // Library is ready to ship.
+  LIBRARY_DAM_ENABLED: z
+    .union([z.literal("true"), z.literal("false")])
+    .default("false")
+    .transform((v) => v === "true"),
+
   // Auth
   NEXTAUTH_URL: z.string().url().optional(),
   NEXTAUTH_SECRET: z.string().min(1),
@@ -49,6 +57,13 @@ const envSchema = z.object({
 
   // Prompt Improver
   MISTRAL_API_KEY: z.string().optional(),
+
+  // Library/DAM — embedding pipeline (Replicate clip-features, ViT-L/14, 768-dim)
+  REPLICATE_API_TOKEN: z.string().optional(),
+  EMBEDDING_MODEL: z.string().default("andreasjansson/clip-features"),
+  EMBEDDING_DIM: z.coerce.number().int().positive().default(768),
+  EMBEDDING_BATCH_SIZE: z.coerce.number().int().positive().default(50),
+  EMBEDDING_CRON_INTERVAL_MIN: z.coerce.number().int().positive().default(2),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/lib/workspace/brand-kit.ts
+++ b/src/lib/workspace/brand-kit.ts
@@ -47,7 +47,7 @@ export interface KitRow {
   bannedTerms: string[];
   defaultLoraId: string | null;
   defaultLoraIds: string[];
-  anchorReferenceIds: string[];
+  anchorAssetIds: string[];
   workspaceDefaultLoraId: string | null;
 }
 
@@ -60,7 +60,7 @@ async function loadKit(brandId: string, workspaceId: string): Promise<KitRow | n
       bannedTerms: brands.bannedTerms,
       defaultLoraId: brands.defaultLoraId,
       defaultLoraIds: brands.defaultLoraIds,
-      anchorReferenceIds: brands.anchorReferenceIds,
+      anchorAssetIds: brands.anchorAssetIds,
       workspaceDefaultLoraId: workspaces.defaultLoraId,
     })
     .from(brands)
@@ -80,7 +80,7 @@ async function loadKit(brandId: string, workspaceId: string): Promise<KitRow | n
     bannedTerms: r.bannedTerms ?? [],
     defaultLoraId: r.defaultLoraId,
     defaultLoraIds: r.defaultLoraIds ?? [],
-    anchorReferenceIds: r.anchorReferenceIds ?? [],
+    anchorAssetIds: r.anchorAssetIds ?? [],
     workspaceDefaultLoraId: r.workspaceDefaultLoraId,
   };
 }
@@ -150,7 +150,7 @@ export function composeKit(
 
   // 4. Anchor reference inclusion — silent if user provided none.
   const imageInputFinal =
-    userRefs.length > 0 ? userRefs : kit.anchorReferenceIds;
+    userRefs.length > 0 ? userRefs : kit.anchorAssetIds;
 
   return {
     promptFinal,

--- a/tests/integration/approval-flow.test.ts
+++ b/tests/integration/approval-flow.test.ts
@@ -192,8 +192,10 @@ describe("approval flow (T101)", () => {
 
   describe("fork-related invariants", () => {
     it("fork target is a draft with parent lineage — encoded as a contract", () => {
-      // The route writes status='draft', source='fork', parentAssetId=source.id,
-      // and a review-log row with action='forked'. Asserted by the post-fork
+      // The route writes status='draft', source='generated' (Library/DAM
+      // unification 0016 collapsed the legacy 'fork' value into 'generated';
+      // lineage is captured by parentAssetId), parentAssetId=source.id, and
+      // a review-log row with action='forked'. Asserted by the post-fork
       // shape returned to the client.
       const forkResponse = {
         asset: {
@@ -201,11 +203,11 @@ describe("approval flow (T101)", () => {
           brandId: BRAND_A,
           parentAssetId: "source-id",
           status: "draft" as const,
-          source: "fork" as const,
+          source: "generated" as const,
         },
       };
       expect(forkResponse.asset.status).toBe("draft");
-      expect(forkResponse.asset.source).toBe("fork");
+      expect(forkResponse.asset.source).toBe("generated");
       expect(forkResponse.asset.parentAssetId).toBe("source-id");
     });
   });

--- a/tests/integration/brand-delete.test.ts
+++ b/tests/integration/brand-delete.test.ts
@@ -170,17 +170,17 @@ async function seedFixture(pool: Pool): Promise<Fixture> {
   // Three assets on the source brand, in different statuses.
   const a1 = await pool.query<{ id: string }>(
     `INSERT INTO assets (user_id, brand_id, model, provider, prompt, r2_key, r2_url, status, source)
-       VALUES ($1, $2, 'm', 'p', 'p1', 'k1', 'u1', 'draft', 'generation') RETURNING id`,
+       VALUES ($1, $2, 'm', 'p', 'p1', 'k1', 'u1', 'draft', 'generated') RETURNING id`,
     [creator.rows[0].id, source.rows[0].id]
   );
   const a2 = await pool.query<{ id: string }>(
     `INSERT INTO assets (user_id, brand_id, model, provider, prompt, r2_key, r2_url, status, source)
-       VALUES ($1, $2, 'm', 'p', 'p2', 'k2', 'u2', 'in_review', 'generation') RETURNING id`,
+       VALUES ($1, $2, 'm', 'p', 'p2', 'k2', 'u2', 'in_review', 'generated') RETURNING id`,
     [creator.rows[0].id, source.rows[0].id]
   );
   const a3 = await pool.query<{ id: string }>(
     `INSERT INTO assets (user_id, brand_id, model, provider, prompt, r2_key, r2_url, status, source)
-       VALUES ($1, $2, 'm', 'p', 'p3', 'k3', 'u3', 'approved', 'generation') RETURNING id`,
+       VALUES ($1, $2, 'm', 'p', 'p3', 'k3', 'u3', 'approved', 'generated') RETURNING id`,
     [creator.rows[0].id, source.rows[0].id]
   );
 

--- a/tests/integration/brand-kit.test.ts
+++ b/tests/integration/brand-kit.test.ts
@@ -21,7 +21,7 @@ const NO_KIT: KitRow = {
   bannedTerms: [],
   defaultLoraId: null,
   defaultLoraIds: [],
-  anchorReferenceIds: [],
+  anchorAssetIds: [],
   workspaceDefaultLoraId: null,
 };
 
@@ -194,7 +194,7 @@ describe("composeKit — anchor reference inclusion (FR-016)", () => {
   it("user-supplied refs win — anchors silent", () => {
     const kit: KitRow = {
       ...NO_KIT,
-      anchorReferenceIds: ["anchor-1", "anchor-2"],
+      anchorAssetIds: ["anchor-1", "anchor-2"],
     };
     const out = composeKit(
       baseInput({ imageInput: ["user-ref"] }),
@@ -206,7 +206,7 @@ describe("composeKit — anchor reference inclusion (FR-016)", () => {
   it("no user refs → kit anchors flow through", () => {
     const kit: KitRow = {
       ...NO_KIT,
-      anchorReferenceIds: ["anchor-1", "anchor-2"],
+      anchorAssetIds: ["anchor-1", "anchor-2"],
     };
     expect(composeKit(baseInput(), kit).imageInputFinal).toEqual([
       "anchor-1",
@@ -219,7 +219,7 @@ describe("composeKit — anchor reference inclusion (FR-016)", () => {
   });
 
   it("override=true skips anchor inclusion", () => {
-    const kit: KitRow = { ...NO_KIT, anchorReferenceIds: ["anchor-1"] };
+    const kit: KitRow = { ...NO_KIT, anchorAssetIds: ["anchor-1"] };
     expect(
       composeKit(baseInput({ override: true }), kit).imageInputFinal
     ).toEqual([]);

--- a/tests/integration/library-filters.test.ts
+++ b/tests/integration/library-filters.test.ts
@@ -1,0 +1,200 @@
+/**
+ * E2E (T030): combine brand + tag + source filters via URL, share the URL,
+ * reload, verify identical results.
+ *
+ * The test is in two halves:
+ *
+ *   1. **URL contract round-trip** (pure, no DB). Asserts that a multi-filter
+ *      URL parses → serializes → parses to an identical query object. This
+ *      is what makes deep links shareable: as long as the contract is stable,
+ *      pasting a URL into a new tab reproduces the exact same filter set.
+ *
+ *   2. **Route handler smoke** (gated on E2E_ENABLED). Inserts a small set
+ *      of assets with deliberately distinct (brand, tag, source) tuples,
+ *      hits `GET /api/library` with each filter combo, asserts the right
+ *      asset is returned, then runs the same request a second time using
+ *      the encoded URL from step 1's parser to prove the deep-link path
+ *      and the toggled-chip path collapse to the same SQL.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import {
+  parseLibraryQuery,
+  serializeLibraryQuery,
+} from "@/app/(dashboard)/library/use-library-query";
+import { getUserId } from "../utils/get-user";
+
+// Auth + flag mocks mirror tests/integration/library-upload-generate.test.ts.
+const sessionState: { userId: string | null } = { userId: null };
+
+vi.mock("@/lib/auth", () => ({
+  auth: async () =>
+    sessionState.userId ? { user: { id: sessionState.userId } } : null,
+}));
+
+vi.mock("@/lib/env", async () => {
+  const real = await vi.importActual<typeof import("@/lib/env")>("@/lib/env");
+  return { ...real, env: { ...real.env, LIBRARY_DAM_ENABLED: true } };
+});
+
+const enabled = process.env.E2E_ENABLED === "true";
+const itOrSkip = enabled ? it : it.skip;
+
+// ---------------------------------------------------------------------------
+// Pure URL contract — runs always.
+// ---------------------------------------------------------------------------
+
+describe("library URL contract round-trip (T030 — pure)", () => {
+  it("multi-filter URL parses, serializes, and parses to itself", () => {
+    const original = new URLSearchParams(
+      "q=hero+shot" +
+        "&brand=11111111-1111-1111-1111-111111111111" +
+        "&tag=studio&tag=blue&tagOp=and" +
+        "&source=generated&source=uploaded" +
+        "&status=approved"
+    );
+
+    const parsed = parseLibraryQuery(original);
+    expect(parsed).toEqual({
+      q: "hero shot",
+      brand: "11111111-1111-1111-1111-111111111111",
+      campaign: null,
+      tags: ["studio", "blue"],
+      tagOp: "and",
+      sources: ["generated", "uploaded"],
+      statuses: ["approved"],
+    });
+
+    const re = serializeLibraryQuery(parsed);
+    const reparsed = parseLibraryQuery(re);
+    expect(reparsed).toEqual(parsed);
+  });
+
+  it("absent tagOp defaults to or; OR omits the param on serialize", () => {
+    const sp = new URLSearchParams("tag=a&tag=b");
+    const parsed = parseLibraryQuery(sp);
+    expect(parsed.tagOp).toBe("or");
+    const re = serializeLibraryQuery(parsed).toString();
+    expect(re).not.toContain("tagOp");
+  });
+
+  it("invalid source/status values are dropped (defensive parse)", () => {
+    const sp = new URLSearchParams(
+      "source=generated&source=bogus&status=approved&status=invalid"
+    );
+    const parsed = parseLibraryQuery(sp);
+    expect(parsed.sources).toEqual(["generated"]);
+    expect(parsed.statuses).toEqual(["approved"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route smoke — gated on E2E_ENABLED.
+// ---------------------------------------------------------------------------
+
+describe("library filters via route (T030 — e2e)", () => {
+  let userId: string;
+  // Track every asset we insert so the afterAll can scrub them.
+  const insertedAssetIds: string[] = [];
+  const baseTag = `t30-${Date.now()}`;
+
+  beforeAll(async () => {
+    if (!enabled) return;
+    userId = await getUserId();
+    sessionState.userId = userId;
+  });
+
+  afterAll(async () => {
+    sessionState.userId = null;
+    if (!enabled || insertedAssetIds.length === 0) return;
+    const { db } = await import("@/lib/db");
+    const { assets, assetTags } = await import("@/lib/db/schema");
+    await db.delete(assetTags).where(inArray(assetTags.assetId, insertedAssetIds));
+    await db.delete(assets).where(inArray(assets.id, insertedAssetIds));
+  });
+
+  itOrSkip(
+    "deep-link URL with brand + tag + source returns the seeded asset",
+    async () => {
+      const { db } = await import("@/lib/db");
+      const { assets, assetTags, brands } = await import("@/lib/db/schema");
+
+      // Find a brand owned by this user — use Personal so we never collide
+      // with concurrent test runs touching real brands.
+      const [personal] = await db
+        .select({ id: brands.id })
+        .from(brands)
+        .where(eq(brands.ownerId, userId))
+        .limit(1);
+      expect(personal?.id).toBeTruthy();
+
+      // Seed two assets:
+      //   match — brand=Personal, source=uploaded, tag=baseTag
+      //   miss  — brand=Personal, source=generated, no tag
+      const [match] = await db
+        .insert(assets)
+        .values({
+          userId,
+          brandId: personal!.id,
+          source: "uploaded",
+          mediaType: "image",
+          model: "test",
+          provider: "test",
+          prompt: "filter-match",
+          fileName: `t30-match-${Date.now()}.png`,
+          r2Key: "test/t30-match.png",
+          r2Url: "https://example/t30-match.png",
+        })
+        .returning({ id: assets.id });
+      const [miss] = await db
+        .insert(assets)
+        .values({
+          userId,
+          brandId: personal!.id,
+          source: "generated",
+          mediaType: "image",
+          model: "test",
+          provider: "test",
+          prompt: "filter-miss",
+          fileName: `t30-miss-${Date.now()}.png`,
+          r2Key: "test/t30-miss.png",
+          r2Url: "https://example/t30-miss.png",
+        })
+        .returning({ id: assets.id });
+      insertedAssetIds.push(match.id, miss.id);
+      await db.insert(assetTags).values({ assetId: match.id, tag: baseTag });
+
+      const { GET: libraryGET } = await import("@/app/api/library/route");
+
+      // Build the URL by toggling chips (parser → serializer round-trip)
+      // and confirm the deep link reproduces it.
+      const togglePath = serializeLibraryQuery({
+        q: "",
+        brand: personal!.id,
+        campaign: null,
+        tags: [baseTag],
+        tagOp: "or",
+        sources: ["uploaded"],
+        statuses: [],
+      });
+
+      const req = new Request(`http://localhost/api/library?${togglePath}`);
+      const res = await libraryGET(req as unknown as Parameters<typeof libraryGET>[0]);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      const ids = data.items.map((it) => it.id);
+      expect(ids).toContain(match.id);
+      expect(ids).not.toContain(miss.id);
+
+      // Reload the same URL — identical results.
+      const req2 = new Request(`http://localhost/api/library?${togglePath}`);
+      const res2 = await libraryGET(req2 as unknown as Parameters<typeof libraryGET>[0]);
+      const data2 = (await res2.json()) as { items: Array<{ id: string }> };
+      expect(data2.items.map((it) => it.id)).toEqual(ids);
+    }
+  );
+});

--- a/tests/integration/library-search.test.ts
+++ b/tests/integration/library-search.test.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E (T031): full-text search by partial filename and partial tag name.
+ *
+ * Phase 2 already shipped the `tags_text` denormalized column maintained by
+ * a trigger on `asset_tags` plus a generated `search_vector tsvector`. This
+ * test asserts the API surface (T025) wires that plumbing through correctly:
+ *
+ *   - Seeded asset A has `file_name = 'hero-shot-001.png'`, no tags.
+ *   - Seeded asset B has `file_name = 'plain.png'`, tag = `hero-spring`.
+ *   - Both should match `q=hero` because `search_vector` covers file_name +
+ *     prompt + tags_text.
+ *   - Ordering: ts_rank gives a deterministic ranking; we verify both come
+ *     back, scoped to the test user.
+ *
+ * Gated on E2E_ENABLED so non-DB CI runs self-skip.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { getUserId } from "../utils/get-user";
+
+const sessionState: { userId: string | null } = { userId: null };
+
+vi.mock("@/lib/auth", () => ({
+  auth: async () =>
+    sessionState.userId ? { user: { id: sessionState.userId } } : null,
+}));
+
+vi.mock("@/lib/env", async () => {
+  const real = await vi.importActual<typeof import("@/lib/env")>("@/lib/env");
+  return { ...real, env: { ...real.env, LIBRARY_DAM_ENABLED: true } };
+});
+
+const enabled = process.env.E2E_ENABLED === "true";
+const itOrSkip = enabled ? it : it.skip;
+
+describe("library FTS via /api/library?q=… (T031)", () => {
+  let userId: string;
+  const insertedAssetIds: string[] = [];
+  const stamp = Date.now();
+  // Use a unique substring that won't collide with anything else in the user's
+  // library — the test asserts equality against a precise expectation.
+  const needle = `t31qry${stamp}`;
+
+  beforeAll(async () => {
+    if (!enabled) return;
+    userId = await getUserId();
+    sessionState.userId = userId;
+  });
+
+  afterAll(async () => {
+    sessionState.userId = null;
+    if (!enabled || insertedAssetIds.length === 0) return;
+    const { db } = await import("@/lib/db");
+    const { assets, assetTags } = await import("@/lib/db/schema");
+    await db.delete(assetTags).where(inArray(assetTags.assetId, insertedAssetIds));
+    await db.delete(assets).where(inArray(assets.id, insertedAssetIds));
+  });
+
+  itOrSkip(
+    "matches filenames AND tag names (tsvector covers both)",
+    async () => {
+      const { db } = await import("@/lib/db");
+      const { assets, assetTags, brands } = await import("@/lib/db/schema");
+
+      const [personal] = await db
+        .select({ id: brands.id })
+        .from(brands)
+        .where(eq(brands.ownerId, userId))
+        .limit(1);
+      expect(personal?.id).toBeTruthy();
+
+      // Asset A — needle is in file_name only.
+      const [a] = await db
+        .insert(assets)
+        .values({
+          userId,
+          brandId: personal!.id,
+          source: "uploaded",
+          mediaType: "image",
+          model: "test",
+          provider: "test",
+          prompt: "blank",
+          fileName: `${needle}-shot-001.png`,
+          r2Key: `test/${needle}-a.png`,
+          r2Url: `https://example/${needle}-a.png`,
+        })
+        .returning({ id: assets.id });
+
+      // Asset B — needle is in tag only.
+      const [b] = await db
+        .insert(assets)
+        .values({
+          userId,
+          brandId: personal!.id,
+          source: "generated",
+          mediaType: "image",
+          model: "test",
+          provider: "test",
+          prompt: "blank",
+          fileName: "plain.png",
+          r2Key: `test/${needle}-b.png`,
+          r2Url: `https://example/${needle}-b.png`,
+        })
+        .returning({ id: assets.id });
+
+      insertedAssetIds.push(a.id, b.id);
+
+      // Insert the tag — the trigger updates tags_text + search_vector.
+      await db.insert(assetTags).values({ assetId: b.id, tag: `${needle}-tag` });
+
+      // Asset C — should NOT match (no needle anywhere).
+      const [c] = await db
+        .insert(assets)
+        .values({
+          userId,
+          brandId: personal!.id,
+          source: "generated",
+          mediaType: "image",
+          model: "test",
+          provider: "test",
+          prompt: "irrelevant",
+          fileName: "noise.png",
+          r2Key: `test/${needle}-c.png`,
+          r2Url: `https://example/${needle}-c.png`,
+        })
+        .returning({ id: assets.id });
+      insertedAssetIds.push(c.id);
+
+      const { GET: libraryGET } = await import("@/app/api/library/route");
+
+      // Search with the unique needle — both A and B should match.
+      const url = `http://localhost/api/library?q=${encodeURIComponent(
+        needle
+      )}&limit=50`;
+      const req = new Request(url);
+      const res = await libraryGET(
+        req as unknown as Parameters<typeof libraryGET>[0]
+      );
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as {
+        items: Array<{ id: string; fileName: string | null }>;
+        total: number;
+      };
+
+      const ids = data.items.map((it) => it.id);
+      expect(ids).toContain(a.id);
+      expect(ids).toContain(b.id);
+      expect(ids).not.toContain(c.id);
+      expect(data.total).toBeGreaterThanOrEqual(2);
+    }
+  );
+});

--- a/tests/integration/library-upload-generate.test.ts
+++ b/tests/integration/library-upload-generate.test.ts
@@ -1,0 +1,170 @@
+/**
+ * E2E (T023): upload → library → generate round-trip.
+ *
+ * Exercises the full Library / DAM cutover plumbing end-to-end:
+ *   1. POST /api/uploads with NO `brandId` — must fold into Personal brand
+ *      and write to `assets` with `source = 'uploaded'` (T015 / FR-008).
+ *   2. GET /api/library — the freshly-uploaded asset must appear with the
+ *      expected superset shape (T011, FR-001).
+ *   3. POST /api/generate with `imageInput` set to the asset's `url` —
+ *      mocked at the provider boundary so the test doesn't burn Replicate
+ *      credit, but every layer above the provider runs for real.
+ *
+ * Gate: `E2E_ENABLED=true`. The harness in `guard.ts` exits early when
+ * unset. We additionally flip `LIBRARY_DAM_ENABLED` for the duration of the
+ * test — the flag is checked once at module import time on the route, but
+ * `vi.mock` lets us override the env helper.
+ *
+ * Run with:  E2E_ENABLED=true LIBRARY_DAM_ENABLED=true pnpm test:e2e
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getUserId } from "../utils/get-user";
+
+// `auth()` returns whatever this object is at the time it's called, so the
+// individual tests can switch user mid-suite. The default is set in beforeAll.
+const sessionState: { userId: string | null } = { userId: null };
+
+vi.mock("@/lib/auth", () => ({
+  auth: async () => (sessionState.userId ? { user: { id: sessionState.userId } } : null),
+}));
+
+// LIBRARY_DAM_ENABLED is sealed at module-import (Zod validates once); flip it
+// before any of the route modules import the env. Vitest hoists vi.mock so
+// the env file is replaced before the routes resolve their `env` import.
+vi.mock("@/lib/env", async () => {
+  const real = await vi.importActual<typeof import("@/lib/env")>("@/lib/env");
+  return {
+    ...real,
+    env: { ...real.env, LIBRARY_DAM_ENABLED: true },
+  };
+});
+
+// Replicate / provider call is the only thing we shortcut. Everything else
+// (uploads, db writes, library list query, generate scheduling) runs live.
+vi.mock("@/providers/registry", async () => {
+  const { Buffer } = await import("node:buffer");
+  // 1x1 transparent PNG.
+  const tinyPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/0lwAAAAAA",
+    "base64"
+  );
+  return {
+    getProvider: (modelId: string) => ({
+      provider: "mock",
+      costPerImage: 0,
+      generate: async () => ({
+        status: "completed" as const,
+        imageBuffer: tinyPng,
+        width: 1,
+        height: 1,
+        format: "png",
+        modelId,
+      }),
+    }),
+  };
+});
+
+const enabled = process.env.E2E_ENABLED === "true";
+const itOrSkip = enabled ? it : it.skip;
+
+describe("library upload → list → generate (T023)", () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    if (!enabled) return;
+    userId = await getUserId();
+    sessionState.userId = userId;
+  });
+
+  afterAll(() => {
+    sessionState.userId = null;
+  });
+
+  itOrSkip("uploads → library → uses asset as image input", async () => {
+    const { POST: uploadsPOST } = await import("@/app/api/uploads/route");
+    const { GET: libraryGET } = await import("@/app/api/library/route");
+
+    // 1. Upload — no brandId, expect Personal-brand fold + source='uploaded'.
+    const fileBuffer = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/0lwAAAAAA",
+      "base64"
+    );
+    const file = new File([fileBuffer], "library-e2e.png", { type: "image/png" });
+    const formData = new FormData();
+    formData.append("file", file);
+    const uploadReq = new Request("http://localhost/api/uploads", {
+      method: "POST",
+      body: formData,
+    });
+
+    const uploadRes = await uploadsPOST(uploadReq as unknown as Parameters<typeof uploadsPOST>[0]);
+    expect(uploadRes.status).toBe(200);
+    const uploadJson = (await uploadRes.json()) as {
+      url: string;
+      asset: { id: string; url: string };
+    };
+    // Top-level `url` keeps the legacy generate-client picker working unchanged.
+    expect(uploadJson.url).toBeTruthy();
+    expect(uploadJson.asset.id).toBeTruthy();
+    expect(uploadJson.asset.url).toBe(uploadJson.url);
+
+    const newAssetId = uploadJson.asset.id;
+
+    // 2. Library list — the new asset must be present.
+    const listReq = new Request("http://localhost/api/library?limit=50");
+    const listRes = await libraryGET(listReq as unknown as Parameters<typeof libraryGET>[0]);
+    expect(listRes.status).toBe(200);
+    const listJson = (await listRes.json()) as {
+      items: Array<{
+        id: string;
+        source: string;
+        url: string;
+        fileName: string | null;
+        tags: string[];
+        campaigns: string[];
+        embeddedAt: string | null;
+        usageCount: number;
+      }>;
+      nextCursor: string | null;
+    };
+    const found = listJson.items.find((it) => it.id === newAssetId);
+    expect(found).toBeDefined();
+    expect(found!.source).toBe("uploaded");
+    expect(found!.fileName).toBe("library-e2e.png");
+    // Library superset fields are present.
+    expect(Array.isArray(found!.tags)).toBe(true);
+    expect(Array.isArray(found!.campaigns)).toBe(true);
+    expect(found!.usageCount).toBe(0);
+
+    // 3. Generate using the asset URL as image input. The provider is mocked;
+    // every other layer runs live. We call the provider directly as the
+    // canonical "use as input" smoke (the actual /api/generate route does
+    // dozens of other things — model resolution, brand-kit, XP — that aren't
+    // load-bearing for this flow). The contract under test is: a Library
+    // asset's `url` is a valid image-input value, and the provider can be
+    // invoked with it without exploding.
+    const { getProvider } = await import("@/providers/registry");
+    const provider = getProvider("flux-dev");
+    expect(provider).toBeTruthy();
+    const result = await provider!.generate({
+      prompt: "library-as-input smoke",
+      model: "flux-dev",
+      imageInput: [found!.url],
+    });
+    expect(result.status).toBe("completed");
+    expect(result.imageBuffer).toBeInstanceOf(Buffer);
+
+    // Cleanup — delete the upload through the library DELETE route so the
+    // test is idempotent across runs.
+    const { DELETE: libraryDELETE } = await import("@/app/api/library/[id]/route");
+    const deleteReq = new Request(
+      `http://localhost/api/library/${newAssetId}`,
+      { method: "DELETE" }
+    );
+    const deleteRes = await libraryDELETE(deleteReq as unknown as Parameters<typeof libraryDELETE>[0], {
+      params: Promise.resolve({ id: newAssetId }),
+    });
+    expect(deleteRes.status).toBe(200);
+  });
+});

--- a/tests/integration/migrate-references-to-assets.test.ts
+++ b/tests/integration/migrate-references-to-assets.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Integration test for the references → assets backfill (T010).
+ *
+ * Skipped unless `INTEGRATION_DATABASE_URL` is set. Mirrors the pattern in
+ * `migration.test.ts`: point the env var at a disposable Postgres (Neon
+ * preview branch, local docker), the test wipes the schema and replays
+ * every drizzle migration up to 0016 to land at the post-Phase-2 baseline,
+ * seeds fixtures, and exercises `runMigration`.
+ *
+ * Fixtures match the spec's T010 acceptance matrix:
+ *   A. ref with brandId, brand has the ref as anchor → asset created, brand
+ *      anchor retargeted to the new asset id.
+ *   B. ref without brandId → asset created, no brand touched.
+ *   C. brand with mixed anchors (some refs we own, some unrelated UUIDs) →
+ *      unrelated UUIDs are reported as `unmappedAnchorIds`, brand row is
+ *      NOT updated, error logged.
+ *   D. re-run after fixture A → 0 inserts, verifier reports
+ *      `assetsAlreadyMigrated > 0` and brand anchors unchanged.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+import { runMigration } from "../../scripts/migrate-references-to-assets";
+
+dotenv.config({ path: ".env.local" });
+
+const url = process.env.INTEGRATION_DATABASE_URL;
+const enabled = !!url;
+const pool = enabled ? new Pool({ connectionString: url }) : null;
+
+const migrationsDir = path.join(process.cwd(), "drizzle");
+
+async function exec(sqlText: string) {
+  if (!pool) throw new Error("pool unset");
+  const stmts = sqlText
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const stmt of stmts) {
+    await pool.query(stmt);
+  }
+}
+
+async function applyMigration(file: string) {
+  const sqlText = fs.readFileSync(path.join(migrationsDir, file), "utf8");
+  await exec(sqlText);
+}
+
+async function freshDb() {
+  if (!pool) return;
+  await pool.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+}
+
+async function applyAllMigrationsThrough(maxIdx: number) {
+  const files = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  for (const f of files) {
+    const idx = parseInt(f.split("_")[0], 10);
+    if (Number.isNaN(idx) || idx > maxIdx) continue;
+    await applyMigration(f);
+  }
+}
+
+interface Fixture {
+  userId: string;
+  workspaceId: string;
+  brandWithAnchor: string;
+  brandWithoutAnchor: string;
+  brandWithMixedAnchors: string;
+  refWithBrand: string;       // anchored on brandWithAnchor
+  refWithoutBrand: string;    // no brand
+  refForMixedBrand: string;   // anchored on brandWithMixedAnchors (alongside random uuid)
+  unrelatedUuid: string;
+}
+
+async function seedFixture(): Promise<Fixture> {
+  if (!pool) throw new Error("pool unset");
+
+  // User + workspace + workspace membership
+  const { rows: userRows } = await pool.query<{ id: string }>(
+    `INSERT INTO users (email, name, role) VALUES ('test@example.com','Test','member') RETURNING id`
+  );
+  const userId = userRows[0].id;
+
+  const { rows: wsRows } = await pool.query<{ id: string }>(
+    `INSERT INTO workspaces (name, slug, mode, created_by)
+     VALUES ('Test WS', 'test-ws', 'hosted', $1)
+     ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+     RETURNING id`,
+    [userId]
+  );
+  const workspaceId = wsRows[0].id;
+
+  await pool.query(
+    `INSERT INTO workspace_members (workspace_id, user_id, role)
+     VALUES ($1, $2, 'owner')
+     ON CONFLICT DO NOTHING`,
+    [workspaceId, userId]
+  );
+
+  // Personal brand — matches the reality of 0009 backfill. References without
+  // brand_id fold into this so the assets.brand_id NOT NULL constraint passes.
+  await pool.query(
+    `INSERT INTO brands (workspace_id, name, slug, color, is_personal, owner_id, created_by)
+     VALUES ($1::uuid, 'Personal', 'personal-' || substr($2::text, 1, 8),
+             '#94a3b8', true, $2::uuid, $2::uuid)`,
+    [workspaceId, userId]
+  );
+
+  // Three brands. brand_members rows so the migration finds them.
+  const { rows: bA } = await pool.query<{ id: string }>(
+    `INSERT INTO brands (workspace_id, name, slug, color, created_by)
+     VALUES ($1, 'Brand A', 'brand-a', '#000000', $2) RETURNING id`,
+    [workspaceId, userId]
+  );
+  const { rows: bB } = await pool.query<{ id: string }>(
+    `INSERT INTO brands (workspace_id, name, slug, color, created_by)
+     VALUES ($1, 'Brand B', 'brand-b', '#000000', $2) RETURNING id`,
+    [workspaceId, userId]
+  );
+  const { rows: bC } = await pool.query<{ id: string }>(
+    `INSERT INTO brands (workspace_id, name, slug, color, created_by)
+     VALUES ($1, 'Brand C', 'brand-c', '#000000', $2) RETURNING id`,
+    [workspaceId, userId]
+  );
+  const brandWithAnchor = bA[0].id;
+  const brandWithoutAnchor = bB[0].id;
+  const brandWithMixedAnchors = bC[0].id;
+
+  for (const id of [brandWithAnchor, brandWithoutAnchor, brandWithMixedAnchors]) {
+    await pool.query(
+      `INSERT INTO brand_members (brand_id, user_id, role)
+       VALUES ($1, $2, 'brand_manager')`,
+      [id, userId]
+    );
+  }
+
+  // References — three rows.
+  const { rows: r1 } = await pool.query<{ id: string }>(
+    `INSERT INTO "references" (user_id, brand_id, r2_key, r2_url, mime_type, file_name, file_size, width, height, usage_count)
+     VALUES ($1, $2, 'r2/k1', 'https://r2/k1', 'image/png', 'a.png', 1234, 800, 600, 3)
+     RETURNING id`,
+    [userId, brandWithAnchor]
+  );
+  const refWithBrand = r1[0].id;
+
+  const { rows: r2 } = await pool.query<{ id: string }>(
+    `INSERT INTO "references" (user_id, r2_key, r2_url, mime_type, file_name)
+     VALUES ($1, 'r2/k2', 'https://r2/k2', 'image/jpeg', 'b.jpg')
+     RETURNING id`,
+    [userId]
+  );
+  const refWithoutBrand = r2[0].id;
+
+  const { rows: r3 } = await pool.query<{ id: string }>(
+    `INSERT INTO "references" (user_id, brand_id, r2_key, r2_url, mime_type, file_name)
+     VALUES ($1, $2, 'r2/k3', 'https://r2/k3', 'image/webp', 'c.webp')
+     RETURNING id`,
+    [userId, brandWithMixedAnchors]
+  );
+  const refForMixedBrand = r3[0].id;
+
+  // Brand A anchored on r1 only.
+  await pool.query(
+    `UPDATE brands SET anchor_asset_ids = $1::jsonb WHERE id = $2`,
+    [JSON.stringify([refWithBrand]), brandWithAnchor]
+  );
+
+  // Brand C anchored on r3 + a random unrelated uuid (fixture C invariant).
+  const unrelatedUuid = "11111111-2222-3333-4444-555555555555";
+  await pool.query(
+    `UPDATE brands SET anchor_asset_ids = $1::jsonb WHERE id = $2`,
+    [JSON.stringify([refForMixedBrand, unrelatedUuid]), brandWithMixedAnchors]
+  );
+
+  return {
+    userId,
+    workspaceId,
+    brandWithAnchor,
+    brandWithoutAnchor,
+    brandWithMixedAnchors,
+    refWithBrand,
+    refWithoutBrand,
+    refForMixedBrand,
+    unrelatedUuid,
+  };
+}
+
+describe.skipIf(!enabled)("migrate-references-to-assets (T009/T010)", () => {
+  let fixture: Fixture;
+
+  beforeAll(async () => {
+    if (!pool) return;
+    await freshDb();
+    await applyAllMigrationsThrough(16);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  beforeEach(async () => {
+    if (!pool) return;
+    // Clear data tables but leave schema intact between fixture runs.
+    await pool.query(`
+      TRUNCATE TABLE "uploads", "asset_review_log", "asset_campaigns",
+        "asset_collections", "asset_tags", "generations", "assets",
+        "campaigns", "brand_members", "references", "brands",
+        "workspace_members", "workspaces", "users"
+        RESTART IDENTITY CASCADE
+    `);
+    fixture = await seedFixture();
+  }, 60_000);
+
+  it("Fixture A: ref+brand → asset created, brand anchor retargeted", async () => {
+    if (!pool) return;
+    const report = await runMigration(pool);
+
+    // The seed deliberately includes the Fixture C scenario (mixed anchors
+    // with an unrelated uuid). Errors scoped to that brand are expected;
+    // assert no *user-level* errors.
+    const userLevelErrors = report.errors.filter((e) => !e.brandId);
+    expect(userLevelErrors).toEqual([]);
+    expect(report.usersProcessed).toBe(1);
+    expect(report.referencesIn).toBe(3);
+    expect(report.assetsInsertedThisRun).toBe(3);
+    expect(report.assetsAlreadyMigrated).toBe(0);
+    expect(report.brandsUpdated).toBeGreaterThanOrEqual(1);
+
+    const { rows: assetForA } = await pool.query<{ id: string }>(
+      `SELECT id FROM "assets" WHERE legacy_reference_id = $1`,
+      [fixture.refWithBrand]
+    );
+    expect(assetForA).toHaveLength(1);
+    const newAssetId = assetForA[0].id;
+
+    const { rows: brandRows } = await pool.query<{ anchor_asset_ids: string[] }>(
+      `SELECT anchor_asset_ids FROM "brands" WHERE id = $1`,
+      [fixture.brandWithAnchor]
+    );
+    expect(brandRows[0].anchor_asset_ids).toEqual([newAssetId]);
+
+    // Asset row carries the right metadata.
+    const { rows: assetMeta } = await pool.query<{
+      source: string;
+      file_name: string | null;
+      file_size: number | null;
+      width: number | null;
+      height: number | null;
+      usage_count: number;
+      brand_id: string | null;
+    }>(
+      `SELECT source, file_name, file_size, width, height, usage_count, brand_id
+         FROM "assets" WHERE id = $1`,
+      [newAssetId]
+    );
+    expect(assetMeta[0].source).toBe("uploaded");
+    expect(assetMeta[0].file_name).toBe("a.png");
+    expect(assetMeta[0].file_size).toBe(1234);
+    expect(assetMeta[0].width).toBe(800);
+    expect(assetMeta[0].height).toBe(600);
+    expect(assetMeta[0].usage_count).toBe(3);
+    expect(assetMeta[0].brand_id).toBe(fixture.brandWithAnchor);
+  });
+
+  it("Fixture B: ref without brandId → asset created, no brand touched", async () => {
+    if (!pool) return;
+    const report = await runMigration(pool);
+    // user-level errors only — brand-scoped errors come from Fixture C and
+    // are expected to coexist with this assertion.
+    const userLevelErrors = report.errors.filter((e) => !e.brandId);
+    expect(userLevelErrors).toEqual([]);
+
+    const { rows } = await pool.query<{
+      brand_id: string | null;
+      file_name: string | null;
+    }>(
+      `SELECT brand_id, file_name FROM "assets"
+        WHERE legacy_reference_id = $1`,
+      [fixture.refWithoutBrand]
+    );
+    expect(rows).toHaveLength(1);
+    // Folded into the user's Personal brand (fixture seeded one to match
+    // the post-0009 production reality).
+    expect(rows[0].brand_id).not.toBeNull();
+    expect(rows[0].file_name).toBe("b.jpg");
+
+    // brandWithoutAnchor was never touched (still empty array).
+    const { rows: brandRows } = await pool.query<{
+      anchor_asset_ids: string[];
+    }>(
+      `SELECT anchor_asset_ids FROM "brands" WHERE id = $1`,
+      [fixture.brandWithoutAnchor]
+    );
+    expect(brandRows[0].anchor_asset_ids).toEqual([]);
+  });
+
+  it("Fixture C: brand with mixed anchors → unmapped reported, brand NOT updated", async () => {
+    if (!pool) return;
+    const report = await runMigration(pool);
+
+    // Refs themselves all migrate fine.
+    expect(report.assetsInsertedThisRun).toBe(3);
+
+    // The unrelated uuid is reported.
+    expect(report.unmappedAnchorIds).toContain(fixture.unrelatedUuid);
+
+    // An error was logged for the mixed brand.
+    expect(
+      report.errors.some(
+        (e) =>
+          e.brandId === fixture.brandWithMixedAnchors &&
+          /Refusing to retarget/.test(e.message)
+      )
+    ).toBe(true);
+
+    // The brand was NOT modified — anchor array still contains the original
+    // reference id (unmapped legacy id) and the unrelated uuid.
+    const { rows } = await pool.query<{ anchor_asset_ids: string[] }>(
+      `SELECT anchor_asset_ids FROM "brands" WHERE id = $1`,
+      [fixture.brandWithMixedAnchors]
+    );
+    expect(rows[0].anchor_asset_ids).toEqual([
+      fixture.refForMixedBrand,
+      fixture.unrelatedUuid,
+    ]);
+  });
+
+  it("Fixture D: re-run is idempotent (0 inserts, alreadyMigrated > 0)", async () => {
+    if (!pool) return;
+    const first = await runMigration(pool);
+    expect(first.assetsInsertedThisRun).toBe(3);
+    expect(first.assetsAlreadyMigrated).toBe(0);
+
+    const second = await runMigration(pool);
+    expect(second.assetsInsertedThisRun).toBe(0);
+    expect(second.assetsAlreadyMigrated).toBe(3);
+    // Brand anchors stay retargeted.
+    const { rows } = await pool.query<{ anchor_asset_ids: string[] }>(
+      `SELECT anchor_asset_ids FROM "brands" WHERE id = $1`,
+      [fixture.brandWithAnchor]
+    );
+    expect(rows[0].anchor_asset_ids).toHaveLength(1);
+    // No new errors on re-run.
+    expect(second.errors.filter((e) => !e.brandId)).toEqual([]);
+  });
+});

--- a/tests/integration/references-redirect.test.ts
+++ b/tests/integration/references-redirect.test.ts
@@ -1,0 +1,84 @@
+/**
+ * E2E (T024): legacy `/references` bookmarks resolve to `/library`.
+ *
+ * Spec FR-007 calls for a 301; Next.js's App Router exposes `redirect()`
+ * (307) and `permanentRedirect()` (308). 308 is 301's modern semantic
+ * equivalent (preserves method + body), so the page uses `permanentRedirect`
+ * and this test asserts 308 plus query-string passthrough.
+ *
+ * `permanentRedirect()` throws a tagged Error whose `digest` field encodes
+ * the destination + status — see `next/dist/client/components/redirect.js`.
+ * Parsing the digest is the cheapest way to assert from a unit-style test
+ * without spinning up a full HTTP server.
+ */
+
+import { describe, expect, it } from "vitest";
+import ReferencesRedirectPage from "@/app/(dashboard)/references/page";
+
+interface RedirectErrorShape {
+  message?: string;
+  digest?: string;
+}
+
+function parseDigest(digest: string) {
+  // Shape: `NEXT_REDIRECT;<type>;<destination>;<statusCode>;`
+  const parts = digest.split(";");
+  const errorCode = parts[0];
+  const type = parts[1];
+  const destination = parts.slice(2, -2).join(";");
+  const status = Number(parts.at(-2));
+  return { errorCode, type, destination, status };
+}
+
+async function captureRedirect(
+  searchParams: Record<string, string | string[] | undefined>
+) {
+  try {
+    await ReferencesRedirectPage({
+      searchParams: Promise.resolve(searchParams),
+    });
+    throw new Error("Expected redirect, got normal return");
+  } catch (err) {
+    const e = err as RedirectErrorShape;
+    if (!e.digest || !e.digest.startsWith("NEXT_REDIRECT;")) {
+      throw err;
+    }
+    return parseDigest(e.digest);
+  }
+}
+
+describe("/references → /library redirect (T024 / FR-007)", () => {
+  it("plain /references redirects to /library with 308", async () => {
+    const { errorCode, destination, status } = await captureRedirect({});
+    expect(errorCode).toBe("NEXT_REDIRECT");
+    expect(destination).toBe("/library");
+    expect(status).toBe(308);
+  });
+
+  it("/references?foo=bar preserves the query string", async () => {
+    const { destination, status } = await captureRedirect({ foo: "bar" });
+    expect(destination).toBe("/library?foo=bar");
+    expect(status).toBe(308);
+  });
+
+  it("preserves multiple query params + array values", async () => {
+    const { destination } = await captureRedirect({
+      brand: "acme",
+      tag: ["a", "b"],
+    });
+    // URLSearchParams round-trips ?brand=acme&tag=a&tag=b in some order; tag
+    // entries are appended in input order so the array is stable.
+    expect(destination.startsWith("/library?")).toBe(true);
+    const params = new URL(`http://x${destination}`).searchParams;
+    expect(params.get("brand")).toBe("acme");
+    expect(params.getAll("tag")).toEqual(["a", "b"]);
+  });
+
+  it("ignores undefined query values without throwing", async () => {
+    const { destination } = await captureRedirect({
+      defined: "yes",
+      missing: undefined,
+    });
+    expect(destination).toBe("/library?defined=yes");
+  });
+});

--- a/tests/utils/save-to-gallery.ts
+++ b/tests/utils/save-to-gallery.ts
@@ -93,7 +93,7 @@ export async function generateAndSave(
       userId,
       brandId,
       status: "draft",
-      source: "generation",
+      source: "generated",
       mediaType: "image",
       model: modelId,
       provider: provider.provider,


### PR DESCRIPTION
## Summary

Closes out the Library / DAM workstream. Phases 2–4 already shipped on this branch; this PR rolls in the polish that turns Library from a "my own assets" grid into a workspace-aware tool.

- **Workspace-aware scope.** Admins see every asset in the workspace; members keep their own. The Brand facet matches the sidebar's rules (admin = workspace, member = `brand_members`), so the dropdown can no longer disagree with what's in the sidebar.
- **Identity in the brand facet.** Personal brands are all literally named "Personal" — useless when an admin sees several at once. Surface the owner's display name + avatar (fallback chain: `users.name` → email local-part → "Personal") and pin personal brands to the top of the dropdown.
- **Status chips on thumbnails.** Each card shows a small chip — Draft / In review / Approved / Rejected / Archived — using the same icon vocabulary as the StatusFacet in the More popover.
- **Creator avatars on thumbnails.** Bottom-right of every card shows the member who created the asset (LEFT JOIN `users` on `assets.user_id`); tooltip is "<name> uploaded/generated/imported this asset".
- **Changelog**: user-facing entry added.

## Files

| File | Change |
|---|---|
| `src/app/(dashboard)/library/page.tsx` | resolves `workspace`/`isAdmin` once; builds `assetScope` SQL fragment used by the asset query, tag facet, and status facet; brand/campaign facets reuse the sidebar's admin-vs-member split; LEFT JOIN `users` for creator + personal-brand owner; threads `status` and `creator` into `LibraryAsset` |
| `src/app/(dashboard)/library/filter-bar.tsx` | `BrandOption` gains `isPersonal` + `ownerImage`; `BrandFacet` renders an avatar for personal rows; new `initialsFor` helper |
| `src/app/(dashboard)/library/library-client.tsx` | new `StatusBadge` (5 variants) and `CreatorAvatar` (with tooltip) on each `LibraryCard`; `LibraryAsset` gains `status` + `creator` fields |
| `src/app/api/library/route.ts` | admin scope swaps `a.user_id = $userId` for `a.brand_id IN (SELECT id FROM brands WHERE workspace_id = $1)`; both raw SQL paths LEFT JOIN `users cu` for creator; `ListRow` + `rowToJoin` extended |
| `src/app/api/library/lib.ts` | `LibraryItem` + `AssetJoinRow` extended with `AssetStatus` and nested `creator`; `loadOwnedLibraryItem` LEFT JOINs `users` |
| `src/lib/changelog.ts` | "Library, upgraded for teams" entry |

## Test plan

- [ ] As a workspace admin, open `/library` and confirm the grid contains every member's assets (not just yours)
- [ ] As a workspace admin, select GIDDI in the Brand filter and confirm Adrian's 6 assets render
- [ ] Personal-brand rows in the dropdown show owner name + avatar (not generic "Personal")
- [ ] Status chip is visible on every thumbnail with the correct color/label per status
- [ ] Creator avatar is visible bottom-right on every card; tooltip reads "<name> uploaded/generated this asset"
- [ ] As a non-admin member, scope is unchanged — only own assets visible
- [ ] Filter URL contract still works: refresh on `?brand=...&status=approved` rehydrates the view
- [ ] FTS search still returns hits and ranking order
- [ ] Cursor pagination on `/api/library` returns no duplicates and fewer rows when filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)