### PR TITLE
feat(library): full-res WebP variant + dual-format API (PR 1 / backend)

### DIFF
--- a/drizzle/0019_webp_variant.sql
+++ b/drizzle/0019_webp_variant.sql
@@ -1,0 +1,47 @@
+-- Migration 0019 — WebP display variant + original mime-type lift.
+--
+-- Adds 5 nullable columns to `assets` to support the write-time WebP encoding
+-- pipeline introduced in PR `feat/webp-image-delivery-backend`:
+--
+--   * webp_r2_key         — R2 key of the encoded display variant
+--                           (`{originalKey}_display.webp`). Null for video
+--                           assets and legacy image rows until the backfill
+--                           script catches them.
+--   * webp_file_size      — bytes; populated alongside webp_r2_key. Surfaced
+--                           in the dual-format download menu in PR 2.
+--   * webp_status         — 'pending' | 'ready' | 'failed' | NULL.
+--                             - NULL  → not applicable (video) OR not yet
+--                                       processed (legacy backlog).
+--                             - 'pending' → backfill picked up the row but
+--                                           hasn't completed (transient).
+--                             - 'ready'   → webp_r2_key + webp_file_size
+--                                           are populated and trustworthy.
+--                             - 'failed'  → encoder threw; original is still
+--                                           valid. Reason in webp_failed_reason.
+--   * webp_failed_reason  — server-side error string. Never surfaced to users.
+--   * original_mime_type  — lifted onto the asset row so the dual-format
+--                           download UI can label "Original (PNG) · 14 MB"
+--                           without joining `uploads` (which doesn't exist
+--                           for `source = 'generated'` rows).
+--
+-- All columns nullable, additive only — no destructive ops, safe to deploy
+-- before the encoder hook code is rolled out (existing rows stay null until
+-- the backfill or new writes touch them; the application code tolerates null
+-- via the `webpStatus IS NULL` branch in the API hydration layer).
+--
+-- Pattern note: text + Drizzle TS-level enum, NOT a Postgres ENUM type. This
+-- matches the rest of the schema (`assets.status`, `assets.source`,
+-- `users.role`, etc.). No CREATE TYPE — we let the application layer enforce
+-- the value set, same as everywhere else.
+--
+-- Idempotent — every column add uses IF NOT EXISTS.
+
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "webp_r2_key" text;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "webp_file_size" integer;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "webp_status" text;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "webp_failed_reason" text;
+--> statement-breakpoint
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "original_mime_type" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777820309000,
       "tag": "0018_smoke",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1777906709000,
+      "tag": "0019_webp_variant",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-webp.ts
+++ b/scripts/backfill-webp.ts
@@ -1,0 +1,269 @@
+/**
+ * backfill-webp.ts — Phase 5 (T013/T014/T015) backfill for the WebP display
+ * variant (specs/webp-image-delivery).
+ *
+ * For every existing image asset that has no WebP variant yet, fetch the
+ * original from R2, encode a `_display.webp` via the same `encodeDisplayWebp`
+ * helper used by the upload + generate routes, PUT to R2, and update the
+ * row to set webp_r2_key / webp_file_size / webp_status / original_mime_type.
+ *
+ * Resumability:
+ *   - The driver loop is `WHERE webp_status IS NULL AND mime_type LIKE
+ *     'image/%' LIMIT 50` re-queried each iteration. There is NO offset
+ *     bookkeeping — once a row's status flips to 'ready' or 'failed' it
+ *     drops out of the working set automatically. Crash-safe: re-running
+ *     resumes from wherever the database state actually is, no checkpoint
+ *     file required.
+ *   - Already-ready rows are silently skipped. Already-failed rows are
+ *     also skipped (their reason is preserved); to retry failures the
+ *     operator can manually `UPDATE assets SET webp_status = NULL WHERE
+ *     webp_status = 'failed'` then re-run.
+ *
+ * Concurrency:
+ *   - Inner `Promise.all` per batch with a hard cap of 4 in-flight
+ *     encodings. Sharp + R2 PUT runs serially within each worker; four
+ *     workers keeps memory well below the M1 Pro / Vercel runner ceiling.
+ *
+ * Failure semantics:
+ *   - Per-row try/catch. A failure persists `webp_status='failed'` with a
+ *     reason and continues; the original asset row is never touched.
+ *
+ * Usage:
+ *   pnpm tsx scripts/backfill-webp.ts                      # real run
+ *   pnpm tsx scripts/backfill-webp.ts --dry-run            # report only
+ *   pnpm tsx scripts/backfill-webp.ts --batch=20 --concurrency=2
+ */
+
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+const BATCH_SIZE_DEFAULT = 50;
+const CONCURRENCY_DEFAULT = 4;
+const LOG_EVERY_DEFAULT = 50;
+
+interface AssetRow {
+  id: string;
+  r2_key: string;
+  mime_type: string | null;
+}
+
+interface BackfillCounters {
+  scanned: number;
+  ready: number;
+  failed: number;
+  totalBytesIn: number;
+  totalBytesOut: number;
+  losslessCount: number;
+}
+
+function parseFlags(argv: string[]) {
+  const dryRun = argv.includes("--dry-run");
+  const batchArg = argv.find((a) => a.startsWith("--batch="));
+  const concurrencyArg = argv.find((a) => a.startsWith("--concurrency="));
+  return {
+    dryRun,
+    batchSize: batchArg ? parseInt(batchArg.slice("--batch=".length), 10) : BATCH_SIZE_DEFAULT,
+    concurrency: concurrencyArg
+      ? parseInt(concurrencyArg.slice("--concurrency=".length), 10)
+      : CONCURRENCY_DEFAULT,
+  };
+}
+
+async function main() {
+  const { dryRun, batchSize, concurrency } = parseFlags(process.argv.slice(2));
+
+  // Dynamic imports so dotenv has loaded BEFORE the storage module's
+  // module-load-time R2 client construction (which reads `process.env.R2_*`).
+  const { Pool } = await import("pg");
+  const { encodeDisplayWebp, displayWebpKey, uploadFile, getAssetUrl } = await import(
+    "@/lib/storage"
+  );
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  // First, take a census so the operator knows the rough scale + estimate.
+  const census = await pool.query<{ count: string; total_bytes: string }>(
+    `SELECT COUNT(*) AS count,
+            COALESCE(SUM(COALESCE(file_size, 0)), 0)::text AS total_bytes
+       FROM assets
+      WHERE webp_status IS NULL
+        AND media_type = 'image'`
+  );
+  const todoCount = parseInt(census.rows[0]?.count ?? "0", 10);
+  const todoBytes = parseInt(census.rows[0]?.total_bytes ?? "0", 10);
+  console.log(
+    `[census] ${todoCount} image assets pending WebP encode; ${(
+      todoBytes /
+      1024 /
+      1024
+    ).toFixed(1)} MB of originals to read.`
+  );
+
+  // R2 cost: Class B operations (GET) for each original read + Class A (PUT)
+  // for each WebP write. As of 2026, R2 lists $0.36 per million Class A and
+  // $4.50 per million Class B. Egress to compute is free for R2.
+  const classA = todoCount; // PUTs
+  const classB = todoCount; // GETs
+  const estUsd = (classA / 1_000_000) * 0.36 + (classB / 1_000_000) * 4.5;
+  console.log(
+    `[census] estimated R2 op cost: $${estUsd.toFixed(4)} (${classA} PUTs + ${classB} GETs)`
+  );
+
+  if (dryRun) {
+    console.log("[dry-run] exiting before any writes.");
+    await pool.end();
+    return;
+  }
+
+  const counters: BackfillCounters = {
+    scanned: 0,
+    ready: 0,
+    failed: 0,
+    totalBytesIn: 0,
+    totalBytesOut: 0,
+    losslessCount: 0,
+  };
+  const startedAt = Date.now();
+  let nextLogAt = LOG_EVERY_DEFAULT;
+
+  // Naturally idempotent loop: re-query "WHERE webp_status IS NULL" each
+  // iteration so completed rows drop out automatically.
+  // Loop until the query returns 0 rows.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { rows } = await pool.query<AssetRow>(
+      `SELECT a.id, a.r2_key, COALESCE(u.content_type, NULL) AS mime_type
+         FROM assets a
+         LEFT JOIN uploads u ON u.asset_id = a.id
+        WHERE a.webp_status IS NULL
+          AND a.media_type = 'image'
+        ORDER BY a.created_at ASC
+        LIMIT $1`,
+      [batchSize]
+    );
+    if (rows.length === 0) break;
+
+    // Process the batch with a concurrency cap.
+    const inflight: Promise<void>[] = [];
+    for (const row of rows) {
+      const task = processOne(row).then(() => {
+        counters.scanned++;
+        if (counters.scanned >= nextLogAt) {
+          const elapsed = (Date.now() - startedAt) / 1000;
+          const rate = counters.scanned / elapsed;
+          console.log(
+            `[progress] ${counters.scanned} processed (${counters.ready} ready / ${counters.failed} failed) — ${rate.toFixed(1)} rows/s`
+          );
+          nextLogAt += LOG_EVERY_DEFAULT;
+        }
+      });
+      inflight.push(task);
+      if (inflight.length >= concurrency) {
+        // Wait for one to clear before dispatching the next. Race resolves
+        // when the fastest in-flight finishes; we then drop it from the list.
+        await Promise.race(inflight.map((p, i) => p.then(() => i)));
+        // Garbage-collect settled promises.
+        for (let i = inflight.length - 1; i >= 0; i--) {
+          // A settled promise resolves immediately on next tick.
+          // We can't introspect status from a Promise, so just await all
+          // and rebuild the list when full. Simplest correct approach:
+          break;
+        }
+        // Drain fully when at cap, then start fresh — keeps the model simple
+        // and the working set bounded. The slight efficiency loss vs a true
+        // sliding-window pool is irrelevant at 4-wide.
+        await Promise.all(inflight);
+        inflight.length = 0;
+      }
+    }
+    // Drain trailing in-flight before re-querying (otherwise we'd re-pick
+    // rows whose status hasn't been updated yet).
+    await Promise.all(inflight);
+  }
+
+  const elapsed = (Date.now() - startedAt) / 1000;
+  console.log("\n[summary]");
+  console.log(`  processed:  ${counters.scanned}`);
+  console.log(`  ready:      ${counters.ready}`);
+  console.log(`  failed:     ${counters.failed}`);
+  console.log(`  lossless:   ${counters.losslessCount}`);
+  console.log(`  bytes in:   ${(counters.totalBytesIn / 1024 / 1024).toFixed(1)} MB`);
+  console.log(`  bytes out:  ${(counters.totalBytesOut / 1024 / 1024).toFixed(1)} MB`);
+  if (counters.totalBytesIn > 0) {
+    const ratio = counters.totalBytesOut / counters.totalBytesIn;
+    console.log(`  ratio out/in: ${(ratio * 100).toFixed(1)}%`);
+  }
+  console.log(`  elapsed:    ${elapsed.toFixed(1)} s`);
+  await pool.end();
+
+  async function processOne(row: AssetRow): Promise<void> {
+    try {
+      const url = await getAssetUrl(row.r2_key);
+      const res = await fetch(url);
+      if (!res.ok) {
+        await markFailed(row.id, `r2_get_${res.status}`);
+        return;
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      counters.totalBytesIn += buf.length;
+      const mime = row.mime_type ?? sniffMime(row.r2_key) ?? "image/png";
+      const enc = await encodeDisplayWebp(buf, mime);
+      if (!enc.ok) {
+        await markFailed(row.id, `encode: ${enc.reason}`, mime);
+        return;
+      }
+      const webpKey = displayWebpKey(row.r2_key);
+      try {
+        await uploadFile(enc.buffer, webpKey, "image/webp");
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        await markFailed(row.id, `r2_put: ${reason}`, mime);
+        return;
+      }
+      counters.totalBytesOut += enc.size;
+      if (enc.usedLossless) counters.losslessCount++;
+      await pool.query(
+        `UPDATE assets
+            SET webp_r2_key = $1,
+                webp_file_size = $2,
+                webp_status = 'ready',
+                webp_failed_reason = NULL,
+                original_mime_type = COALESCE(original_mime_type, $3)
+          WHERE id = $4`,
+        [webpKey, enc.size, mime, row.id]
+      );
+      counters.ready++;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await markFailed(row.id, `unexpected: ${reason}`);
+    }
+  }
+
+  async function markFailed(id: string, reason: string, mime?: string) {
+    await pool.query(
+      `UPDATE assets
+          SET webp_status = 'failed',
+              webp_failed_reason = $1,
+              original_mime_type = COALESCE(original_mime_type, $2)
+        WHERE id = $3`,
+      [reason, mime ?? null, id]
+    );
+    counters.failed++;
+    console.error(`[failed] ${id}: ${reason}`);
+  }
+}
+
+function sniffMime(key: string): string | null {
+  const ext = key.toLowerCase().split(".").pop();
+  if (!ext) return null;
+  if (ext === "png") return "image/png";
+  if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+  if (ext === "webp") return "image/webp";
+  if (ext === "gif") return "image/gif";
+  return null;
+}
+
+main().catch((err) => {
+  console.error("[fatal]", err);
+  process.exit(1);
+});

--- a/src/app/api/assets/[id]/route.ts
+++ b/src/app/api/assets/[id]/route.ts
@@ -54,6 +54,11 @@ export async function GET(
       fileSize: assets.fileSize,
       costEstimate: assets.costEstimate,
       createdAt: assets.createdAt,
+      // PR `feat/webp-image-delivery-backend` additions.
+      webpR2Key: assets.webpR2Key,
+      webpFileSize: assets.webpFileSize,
+      webpStatus: assets.webpStatus,
+      originalMimeType: assets.originalMimeType,
       brandWorkspaceId: brands.workspaceId,
       brandName: brands.name,
       brandColor: brands.color,
@@ -90,11 +95,12 @@ export async function GET(
     .from(assetTags)
     .where(eq(assetTags.assetId, id));
 
-  // Build URL
-  const url = await getAssetUrl(asset.r2Key);
-  const thumbnailUrl = asset.thumbnailR2Key
-    ? await getAssetUrl(asset.thumbnailR2Key)
-    : null;
+  // Build URLs in parallel — saves an R2 round-trip per asset post-backfill.
+  const [url, thumbnailUrl, webpUrl] = await Promise.all([
+    getAssetUrl(asset.r2Key),
+    asset.thumbnailR2Key ? getAssetUrl(asset.thumbnailR2Key) : Promise.resolve(null),
+    asset.webpR2Key ? getAssetUrl(asset.webpR2Key) : Promise.resolve(null),
+  ]);
 
   const brand = asset.brandId
     ? {
@@ -137,6 +143,12 @@ export async function GET(
       fileSize: asset.fileSize,
       costEstimate: asset.costEstimate,
       createdAt: asset.createdAt,
+      // PR `feat/webp-image-delivery-backend` — same shape as Library.
+      webpUrl,
+      webpFileSize: asset.webpFileSize,
+      webpStatus: asset.webpStatus,
+      originalMimeType: asset.originalMimeType,
+      originalFileSize: asset.fileSize,
       brand,
       brands: brand ? [brand] : [],
       tags: assetTagRows.map((t) => t.tag),
@@ -250,6 +262,7 @@ export async function DELETE(
       status: assets.status,
       r2Key: assets.r2Key,
       thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
     })
     .from(assets)
     .where(eq(assets.id, id))
@@ -269,6 +282,9 @@ export async function DELETE(
     await deleteFile(asset.r2Key);
     if (asset.thumbnailR2Key) {
       await deleteFile(asset.thumbnailR2Key);
+    }
+    if (asset.webpR2Key) {
+      await deleteFile(asset.webpR2Key);
     }
   } catch (error) {
     // Log but don't fail - asset will be orphaned in storage

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -130,6 +130,13 @@ export async function GET(req: NextRequest) {
       duration: assets.duration,
       hasAudio: assets.hasAudio,
       createdAt: assets.createdAt,
+      // PR `feat/webp-image-delivery-backend` additions — Gallery hydration
+      // mirrors Library so the shared download component reads the same
+      // shape from both surfaces.
+      webpR2Key: assets.webpR2Key,
+      webpFileSize: assets.webpFileSize,
+      webpStatus: assets.webpStatus,
+      originalMimeType: assets.originalMimeType,
       brandName: brands.name,
       brandColor: brands.color,
       brandIsPersonal: brands.isPersonal,
@@ -183,10 +190,14 @@ export async function GET(req: NextRequest) {
 
   const assetResults = await Promise.all(
     assetRows.map(async (a) => {
-      const url = await getAssetUrl(a.r2Key);
-      const thumbnailUrl = a.thumbnailR2Key
-        ? await getAssetUrl(a.thumbnailR2Key)
-        : null;
+      // Resolve url, thumbnail, and webp variant URLs in parallel — saves a
+      // round-trip per asset when the row has all three keys (typical post-
+      // backfill).
+      const [url, thumbnailUrl, webpUrl] = await Promise.all([
+        getAssetUrl(a.r2Key),
+        a.thumbnailR2Key ? getAssetUrl(a.thumbnailR2Key) : Promise.resolve(null),
+        a.webpR2Key ? getAssetUrl(a.webpR2Key) : Promise.resolve(null),
+      ]);
 
       const brand = a.brandId
         ? {
@@ -230,6 +241,15 @@ export async function GET(req: NextRequest) {
         duration: a.duration,
         hasAudio: a.hasAudio,
         createdAt: a.createdAt,
+        // PR `feat/webp-image-delivery-backend` — surface for PR 2 frontend.
+        // `originalFileSize` is the same value as `fileSize`, named explicitly
+        // so the dual-format download menu reads symmetrically with
+        // `webpFileSize`. `webpStatus` controls the silent-fallback decision.
+        webpUrl,
+        webpFileSize: a.webpFileSize,
+        webpStatus: a.webpStatus,
+        originalMimeType: a.originalMimeType,
+        originalFileSize: a.fileSize,
         brand,
         // Legacy multi-brand shape; until 0010 ships every asset still has one
         // single canonical brand. Kept so older clients keep rendering.

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -3,7 +3,12 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { brands, generations, assets, brandMembers, users } from "@/lib/db/schema";
 import { getProvider } from "@/providers/registry";
-import { uploadAsset } from "@/lib/storage";
+import {
+  uploadAsset,
+  uploadFile,
+  encodeDisplayWebp,
+  displayWebpKey,
+} from "@/lib/storage";
 import { getXPReward, awardXP, checkAndAwardBadges } from "@/lib/xp";
 import { references } from "@/lib/db/schema";
 import { eq, and, gte, sql } from "drizzle-orm";
@@ -429,6 +434,47 @@ export async function POST(req: NextRequest) {
     // Upload to R2
     const uploaded = await uploadAsset(result.imageBuffer, userId);
 
+    // WebP display variant (PR `feat/webp-image-delivery-backend`, T011).
+    // Mirrors the upload-route logic: encode in-process, PUT to R2 at
+    // `{originalKey}_display.webp`, fall through to webpStatus='failed' on
+    // any error so the asset row still saves and the original is served.
+    // `uploadAsset()` always writes PNGs (image/png) for now, so we can pass
+    // the constant mime type.
+    const generatedMimeType = "image/png";
+    let genWebpR2Key: string | null = null;
+    let genWebpFileSize: number | null = null;
+    let genWebpStatus: "ready" | "failed" | null = null;
+    let genWebpFailedReason: string | null = null;
+
+    const encoded = await encodeDisplayWebp(
+      result.imageBuffer,
+      generatedMimeType
+    );
+    if (encoded.ok) {
+      const webpKey = displayWebpKey(uploaded.key);
+      try {
+        await uploadFile(encoded.buffer, webpKey, "image/webp");
+        genWebpR2Key = webpKey;
+        genWebpFileSize = encoded.size;
+        genWebpStatus = "ready";
+      } catch (err) {
+        genWebpStatus = "failed";
+        genWebpFailedReason =
+          err instanceof Error ? `r2_put: ${err.message}` : "r2_put: unknown";
+        console.error(
+          "[generate] WebP variant R2 PUT failed (asset still saved):",
+          { key: uploaded.key, reason: genWebpFailedReason }
+        );
+      }
+    } else {
+      genWebpStatus = "failed";
+      genWebpFailedReason = encoded.reason;
+      console.error(
+        "[generate] WebP encoder failed (asset still saved):",
+        { key: uploaded.key, reason: encoded.reason }
+      );
+    }
+
     // Create asset record. brandId is set; status defaults to draft (FR-010);
     // source = generation; brandKitOverridden tracks whether the kit was
     // skipped (FR-016). Mutation guard at the DB level lives in transitions.ts.
@@ -454,6 +500,13 @@ export async function POST(req: NextRequest) {
         r2Key: uploaded.key,
         r2Url: uploaded.url,
         thumbnailR2Key: uploaded.thumbnailKey,
+        // WebP display variant fields (FR-005). Always set on image
+        // generations; never null here because we always run the encoder.
+        webpR2Key: genWebpR2Key,
+        webpFileSize: genWebpFileSize,
+        webpStatus: genWebpStatus,
+        webpFailedReason: genWebpFailedReason,
+        originalMimeType: generatedMimeType,
         width: uploaded.width,
         height: uploaded.height,
         fileSize: uploaded.fileSize,

--- a/src/app/api/library/[id]/route.ts
+++ b/src/app/api/library/[id]/route.ts
@@ -241,6 +241,7 @@ export async function DELETE(
       userId: assets.userId,
       r2Key: assets.r2Key,
       thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
     })
     .from(assets)
     .where(and(eq(assets.id, id), eq(assets.userId, session.user.id)))
@@ -274,6 +275,9 @@ export async function DELETE(
     await deleteFile(asset.r2Key);
     if (asset.thumbnailR2Key) {
       await deleteFile(asset.thumbnailR2Key);
+    }
+    if (asset.webpR2Key) {
+      await deleteFile(asset.webpR2Key);
     }
   } catch (error) {
     console.error("Failed to delete library asset from storage:", error);

--- a/src/app/api/library/lib.ts
+++ b/src/app/api/library/lib.ts
@@ -52,6 +52,18 @@ export interface LibraryItem {
   campaigns: string[];
   embeddedAt: string | null;
   createdAt: string;
+  // WebP display variant + dual-format download fields. Hydrated for every
+  // item; null when the asset is a video, or pre-backfill, or its encoder
+  // failed. Frontend uses webpStatus to gate the UX (silent fallback to
+  // `url` when not 'ready').
+  webpUrl: string | null;
+  webpFileSize: number | null;
+  webpStatus: "pending" | "ready" | "failed" | null;
+  originalMimeType: string | null;
+  // `fileSize` above is already the original; surfaced again here under an
+  // explicit name so the dual-format download menu reads symmetrically with
+  // `webpFileSize`. Same value, kept distinct for readability.
+  originalFileSize: number | null;
 }
 
 export interface AssetJoinRow {
@@ -75,6 +87,10 @@ export interface AssetJoinRow {
   creatorName: string | null;
   creatorImage: string | null;
   creatorEmail: string | null;
+  webpR2Key: string | null;
+  webpFileSize: number | null;
+  webpStatus: "pending" | "ready" | "failed" | null;
+  originalMimeType: string | null;
 }
 
 /**
@@ -126,16 +142,23 @@ export async function hydrateLibraryItem(
   tags: string[],
   campaigns: string[]
 ): Promise<LibraryItem> {
-  const url = await getAssetUrl(row.r2Key);
-  const thumbnailUrl = row.thumbnailR2Key
-    ? await getAssetUrl(row.thumbnailR2Key)
-    : null;
+  // Resolve all storage URLs in parallel — saves a round-trip when both
+  // thumbnail and webp keys are present.
+  const [url, thumbnailUrl, webpUrl] = await Promise.all([
+    getAssetUrl(row.r2Key),
+    row.thumbnailR2Key ? getAssetUrl(row.thumbnailR2Key) : Promise.resolve(null),
+    row.webpR2Key ? getAssetUrl(row.webpR2Key) : Promise.resolve(null),
+  ]);
 
   // Legacy references always carried `mimeType`. For migrated and newly-
   // uploaded assets the paired `uploads.contentType` carries it; for
   // generations we don't track upstream MIME — fall back to a sensible value
   // derived from `mediaType` so the picker keeps rendering.
+  // Prefer the new `original_mime_type` column when present (the upload +
+  // generate routes populate it on every new write); fall back to the legacy
+  // `uploads.contentType` join, then to a mediaType-derived default.
   const mimeType =
+    row.originalMimeType ??
     row.uploadContentType ??
     (row.mediaType === "video" ? "video/mp4" : "image/png");
 
@@ -165,6 +188,11 @@ export async function hydrateLibraryItem(
     campaigns,
     embeddedAt: row.embeddedAt ? row.embeddedAt.toISOString() : null,
     createdAt: row.createdAt.toISOString(),
+    webpUrl,
+    webpFileSize: row.webpFileSize,
+    webpStatus: row.webpStatus,
+    originalMimeType: mimeType,
+    originalFileSize: row.fileSize,
   };
 }
 
@@ -199,6 +227,10 @@ export async function loadOwnedLibraryItem(
       creatorName: users.name,
       creatorImage: users.image,
       creatorEmail: users.email,
+      webpR2Key: assets.webpR2Key,
+      webpFileSize: assets.webpFileSize,
+      webpStatus: assets.webpStatus,
+      originalMimeType: assets.originalMimeType,
     })
     .from(assets)
     .leftJoin(uploads, eq(uploads.assetId, assets.id))

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -116,6 +116,10 @@ type ListRow = {
   creator_name: string | null;
   creator_image: string | null;
   creator_email: string | null;
+  webp_r2_key: string | null;
+  webp_file_size: number | null;
+  webp_status: "pending" | "ready" | "failed" | null;
+  original_mime_type: string | null;
 };
 
 type ListRowWithCount = ListRow & { total_count: number; [k: string]: unknown };
@@ -158,6 +162,10 @@ function rowToJoin(r: ListRow): AssetJoinRow {
     creatorName: r.creator_name,
     creatorImage: r.creator_image,
     creatorEmail: r.creator_email,
+    webpR2Key: r.webp_r2_key,
+    webpFileSize: r.webp_file_size,
+    webpStatus: r.webp_status,
+    originalMimeType: r.original_mime_type,
   };
 }
 
@@ -306,6 +314,7 @@ export async function GET(req: NextRequest) {
         a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
         a.file_name, a.file_size, a.width, a.height, a.usage_count,
         a.source, a.status, a.embedded_at, a.created_at, a.media_type,
+        a.webp_r2_key, a.webp_file_size, a.webp_status, a.original_mime_type,
         u.content_type AS upload_content_type,
         cu.id AS creator_id,
         cu.name AS creator_name,
@@ -340,6 +349,7 @@ export async function GET(req: NextRequest) {
         a.id, a.user_id, a.brand_id, a.r2_key, a.thumbnail_r2_key,
         a.file_name, a.file_size, a.width, a.height, a.usage_count,
         a.source, a.status, a.embedded_at, a.created_at, a.media_type,
+        a.webp_r2_key, a.webp_file_size, a.webp_status, a.original_mime_type,
         u.content_type AS upload_content_type,
         cu.id AS creator_id,
         cu.name AS creator_name,

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -4,6 +4,8 @@ import {
   uploadFile,
   generateAndUploadThumbnail,
   getAssetUrl,
+  encodeDisplayWebp,
+  displayWebpKey,
 } from "@/lib/storage";
 import { db } from "@/lib/db";
 import { assets, brands, uploads } from "@/lib/db/schema";
@@ -146,6 +148,13 @@ export async function POST(req: NextRequest) {
   let height: number | null = null;
   let thumbnailKey: string | null = null;
 
+  // WebP display variant fields (FR-001..FR-005, FR-013). Populated only for
+  // image uploads; videos leave webpStatus null per the locked decision.
+  let webpR2Key: string | null = null;
+  let webpFileSize: number | null = null;
+  let webpStatus: "ready" | "failed" | null = null;
+  let webpFailedReason: string | null = null;
+
   if (isImage) {
     try {
       const metadata = await sharp(buffer).metadata();
@@ -158,6 +167,36 @@ export async function POST(req: NextRequest) {
       thumbnailKey = await generateAndUploadThumbnail(buffer, key);
     } catch {
       // non-critical
+    }
+
+    // Encode the full-resolution WebP variant. Errors are caught inside the
+    // helper and surfaced via the discriminated return — this never throws.
+    // On success we PUT to `{originalKey}_display.webp`; on failure we still
+    // persist the asset row so the original remains accessible (FR-013).
+    const encoded = await encodeDisplayWebp(buffer, contentType);
+    if (encoded.ok) {
+      const webpKey = displayWebpKey(key);
+      try {
+        await uploadFile(encoded.buffer, webpKey, "image/webp");
+        webpR2Key = webpKey;
+        webpFileSize = encoded.size;
+        webpStatus = "ready";
+      } catch (err) {
+        webpStatus = "failed";
+        webpFailedReason =
+          err instanceof Error ? `r2_put: ${err.message}` : "r2_put: unknown";
+        console.error(
+          "[uploads] WebP variant R2 PUT failed (asset still saved):",
+          { key, reason: webpFailedReason }
+        );
+      }
+    } else {
+      webpStatus = "failed";
+      webpFailedReason = encoded.reason;
+      console.error(
+        "[uploads] WebP encoder failed (asset still saved):",
+        { key, reason: encoded.reason }
+      );
     }
   }
 
@@ -181,6 +220,16 @@ export async function POST(req: NextRequest) {
       r2Key: key,
       r2Url: url,
       thumbnailR2Key: thumbnailKey,
+      // WebP display variant (PR `feat/webp-image-delivery-backend`).
+      // All four fields stay null on video uploads; on image uploads the
+      // status is either 'ready' (key + size set) or 'failed' (reason set).
+      webpR2Key,
+      webpFileSize,
+      webpStatus,
+      webpFailedReason,
+      // Original mime-type lifted onto the row so PR 2's dual-format download
+      // can label "Original (PNG) · 14 MB" without joining `uploads`.
+      originalMimeType: contentType,
       // FR-004: uploads now retain their original filename in the new column.
       fileName: file.name,
       usageCount: 0,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -294,6 +294,23 @@ export const assets = pgTable(
     r2Key: text("r2_key").notNull(),
     r2Url: text("r2_url").notNull(),
     thumbnailR2Key: text("thumbnail_r2_key"),
+    // WebP display variant (migration 0018). Encoded write-time alongside the
+    // 400px thumbnail; consumed by the Library detail panel + Gallery lightbox
+    // and as the primary download. Null on video assets and on legacy rows
+    // until the backfill catches them. `webpStatus = 'failed'` means the
+    // encoder threw for a recoverable reason; the original is still served.
+    // Pattern matches the rest of this schema — text + Drizzle enum, not a
+    // Postgres ENUM type (consistent with `status`, `source`, etc.).
+    webpR2Key: text("webp_r2_key"),
+    webpFileSize: integer("webp_file_size"),
+    webpStatus: text("webp_status", {
+      enum: ["pending", "ready", "failed"],
+    }),
+    webpFailedReason: text("webp_failed_reason"),
+    // Original mime-type lifted onto the asset row so the dual-format download
+    // UI in PR 2 can label "Original (PNG) · 14 MB" without joining `uploads`
+    // (which doesn't exist for `source = 'generated'` rows anyway).
+    originalMimeType: text("original_mime_type"),
     // Library/DAM additions (migration 0016).
     // Original upload filename — uploads now retain this; generations may set
     // a synthesized name. Nullable for legacy rows.

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -107,6 +107,54 @@ export async function refreshImageInputUrls(
 }
 
 /**
+ * Encode a full-resolution WebP "display" variant for an image asset
+ * (PR `feat/webp-image-delivery-backend`, T008).
+ *
+ * Decision rules baked in here:
+ *   - Lossless when `sharp.metadata().hasAlpha === true` (typical for
+ *     OpenAI gpt-image cutouts) — avoids halos around transparent edges.
+ *   - Otherwise lossy quality 85 — consensus sweet spot.
+ *
+ * NEVER throws. Wraps every Sharp call in try/catch and returns the
+ * `{ ok: false, reason }` discriminator so the upload/generate routes
+ * can persist the asset row with `webpStatus = 'failed'` and continue
+ * (FR-013 — encoder failure must not block the asset write).
+ */
+export async function encodeDisplayWebp(
+  buffer: Buffer,
+  mimeType: string
+): Promise<
+  | { ok: true; buffer: Buffer; size: number; usedLossless: boolean }
+  | { ok: false; reason: string }
+> {
+  try {
+    // Skip non-images defensively. Callers should already gate on
+    // mediaType === 'image', but this is the seam — keep it bulletproof.
+    if (!mimeType.startsWith("image/")) {
+      return { ok: false, reason: `unsupported_mime_type: ${mimeType}` };
+    }
+    const meta = await sharp(buffer).metadata();
+    const usedLossless = meta.hasAlpha === true;
+    const out = usedLossless
+      ? await sharp(buffer).webp({ lossless: true }).toBuffer()
+      : await sharp(buffer).webp({ quality: 85 }).toBuffer();
+    return { ok: true, buffer: out, size: out.length, usedLossless };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason };
+  }
+}
+
+/**
+ * Derive the WebP display variant's R2 key from the original asset key.
+ * Centralized so the upload route, generate route, and backfill script all
+ * agree on the layout (`{originalKey}_display.webp`).
+ */
+export function displayWebpKey(originalKey: string): string {
+  return originalKey.replace(/\.[^.]+$/, "_display.webp");
+}
+
+/**
  * Generate a thumbnail and upload it.
  * Returns the thumbnail storage key.
  */


### PR DESCRIPTION
## Summary

PR 1 of 2 for [WebP Image Delivery + Dual-Format Download](../tree/feat/webp-image-delivery-backend/specs/webp-image-delivery). Backend-only — no UI changes. **Replaces #40** (auto-closed when its base branch `feat/library-dam` was deleted after merging into main as #41). Rebased onto current main; migration renumbered from `0018_*` to `0019_*` to avoid collision with `0018_smoke.sql` already on main.

Encodes a full-res WebP variant at write-time alongside the original and the existing 400px thumbnail, then hydrates it onto Library + Gallery DTOs so PR 2's UI can prefer it for viewing surfaces and offer a dual-format download.

- **Schema (migration `0019_webp_variant.sql`)**: 5 new nullable columns on `assets` — `webp_r2_key`, `webp_file_size`, `webp_status`, `webp_failed_reason`, `original_mime_type`. No destructive ops. Text-typed (matches existing codebase pattern; codebase has zero `pgEnum` usage).
- **Encoder** (`src/lib/storage/index.ts → encodeDisplayWebp`): Sharp pipeline. Lossless when `metadata().hasAlpha` (preserves OpenAI alpha cutouts halo-free); lossy q85 otherwise. Catches all errors and returns `{ ok: false, reason }` so the asset write never blocks on encoder failure.
- **Write paths** (`uploads` + `generate` routes): after the original is persisted and the thumbnail is generated, PUT `{originalKey}_display.webp` and persist the 5 new fields. Encoder failures → `webp_status='failed'`, reason logged server-side, row still saves, original still accessible. Videos skipped entirely.
- **Backfill** (`scripts/backfill-webp.ts`): idempotent loop on `WHERE webp_status IS NULL AND mime LIKE 'image/%'`. Concurrency cap 4, `--dry-run` for cost estimation, naturally resumable.
- **API hydration**: Library list + single + Gallery list + single all expose `webpUrl`, `webpFileSize`, `webpStatus`, `originalMimeType`, `originalFileSize`. DELETE cascades remove the WebP key from R2.

### Compression results (dev dataset, prior run)

133.5 MB originals → 9.6 MB WebPs (**7.2% ratio**). NFR-004 (≥60% byte drop) trivially met.

### Backfill results (dev, prior run)

141 ready / 3 failed (2 pre-existing R2 orphans + 1 QA-corrupt-test) / 0 pending → **97.9%** ready (SC-001 ≥95% target met).

## Notes for reviewer

- **Migration renumbered** to `0019_webp_variant.sql` because `0018_smoke.sql` landed on main between when this work started and now. Journal entry follows existing 0018 entry. No data conflict — `0018_smoke.sql` is unrelated.
- **Drizzle-kit `migrate` has pre-existing snapshot drift** (meta snapshots end at 0012, hand-written migrations 0013+ exist). Migration was applied directly via `pg` on the dev Neon branch and is `IF NOT EXISTS`-safe. Production deploy will need the same direct-SQL apply until the snapshot drift is fixed.
- **WebP URLs are signed GETs**: `curl -I` (HEAD) returns 403 against R2 presigned URLs. This is an R2 quirk, not a bug. PR 2's UI uses `<img src>` tags, not HEAD requests.
- **History**: was previously rebased on `feat/library-dam`; now rebased onto `main` (which already includes lib-dam via #41). Force-pushed.

## Test plan

- [x] Prior T019 QA pass — 10/10 functional items pass (opaque PNG → VP8 lossy; alpha PNG → VP8L lossless; JPEG → lossy; corrupt buffer → `webp_status='failed'`, original still saves; backfill idempotent on re-run; video → all WebP fields null; Library/Gallery APIs hydrated with valid signed URLs; DELETE removes WebP blob; `curl webpUrl` → `200 image/webp`, Content-Length matches DB).
- [x] `pnpm tsc --noEmit` — clean on rebased tree
- [ ] Spot-check production p95 latency on first uploads post-merge (NFR-001: <1.5s added latency for ≤4096×4096 images).
- [ ] Run `pnpm tsx scripts/backfill-webp.ts --dry-run` against prod to estimate cost; then run the real backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)