### PR TITLE
feat(review): open into gallery instead of auto-modal (closes #39)

### DIFF
--- a/src/app/(dashboard)/review/review-client.tsx
+++ b/src/app/(dashboard)/review/review-client.tsx
@@ -1,15 +1,27 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
-import { CheckCircle2, ChevronRight, Loader2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ReviewModal,
   type ReviewQueueItem,
 } from "@/components/review-modal";
+import {
+  ReviewTile,
+  ReviewGallerySkeleton,
+} from "@/components/review-tile";
 
 interface PendingBrand {
   brandId: string;
@@ -38,6 +50,7 @@ export function ReviewClient() {
   const [pendingLoading, setPendingLoading] = useState(true);
   const [queue, setQueue] = useState<QueueResponse | null>(null);
   const [queueLoading, setQueueLoading] = useState(false);
+  const [queueError, setQueueError] = useState(false);
   const [modalIndex, setModalIndex] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -75,12 +88,15 @@ export function ReviewClient() {
         }
         const data = (await res.json()) as QueueResponse;
         setQueue(data);
+        setQueueError(false);
         setModalIndex(0);
-        setModalOpen(data.queue.length > 0);
+        // Gallery-first: do NOT auto-open the modal. Reviewers see the grid,
+        // then click a tile to open the modal at that index. (US1, T007)
         if (data.queue.length === 0) {
           toast.message("Queue is empty for this brand.");
         }
       } catch (err) {
+        setQueueError(true);
         toast.error(
           err instanceof Error && err.message === "forbidden"
             ? "You can't review this brand."
@@ -94,6 +110,7 @@ export function ReviewClient() {
   );
 
   useEffect(() => {
+    setQueueError(false);
     if (activeBrandId) {
       loadQueue(activeBrandId);
     } else {
@@ -129,16 +146,30 @@ export function ReviewClient() {
         }
         toast.success(action === "approve" ? "Approved" : "Rejected");
         // Remove the item from the local queue and advance.
+        const remaining = (queue?.queue.length ?? 1) - 1;
         setQueue((prev) => {
           if (!prev) return prev;
           const next = prev.queue.filter((q) => q.id !== item.id);
           return { ...prev, queue: next };
         });
         setModalIndex((i) => {
-          const remaining = (queue?.queue.length ?? 1) - 1;
           if (remaining <= 0) return 0;
           return Math.min(i, remaining - 1);
         });
+        // Designer R1: Base UI's Dialog returnFocus targets the originating
+        // tile, but that tile is unmounted post-action so focus falls back to
+        // <body>. Restore focus to the surviving tile at the modal's index so
+        // a keyboard reviewer (Fern) stays in flow. Skip when the queue empties
+        // — the queue-empty effect navigates to /review and there is no tile.
+        if (remaining > 0) {
+          const targetIndex = Math.min(modalIndex, remaining - 1);
+          requestAnimationFrame(() => {
+            const next = document.querySelector<HTMLButtonElement>(
+              `[data-slot="review-tile"][data-index="${targetIndex}"]`
+            );
+            next?.focus();
+          });
+        }
         refreshPending();
         if (typeof window !== "undefined") {
           window.dispatchEvent(new Event("opencauldron:review-changed"));
@@ -147,20 +178,39 @@ export function ReviewClient() {
         toast.error("Network error");
       }
     },
-    [queue?.queue.length, refreshPending]
+    [queue?.queue.length, modalIndex, refreshPending]
   );
 
+  // US2 (T013): Closing the modal returns the reviewer to the gallery (URL
+  // stays at /review?brand=<id>). Popping back to the brand list is handled
+  // by the queue-empty effect below — only when there is genuinely nothing
+  // left to triage in this brand.
   const closeModal = useCallback(() => {
     setModalOpen(false);
-    router.push("/review");
-  }, [router]);
+  }, []);
 
-  // If queue empties mid-session, close.
+  const handleTileClick = useCallback((index: number) => {
+    setModalIndex(index);
+    setModalOpen(true);
+  }, []);
+
+  const handleQueueRetry = useCallback(() => {
+    if (!activeBrandId) return;
+    setQueueError(false);
+    loadQueue(activeBrandId);
+  }, [activeBrandId, loadQueue]);
+
+  // If the queue empties while the modal is open (last asset reviewed),
+  // close the modal AND pop back to the brand list — there is nothing left
+  // to triage in this brand. (US2 / T013, plan.md "Risks & Mitigations".)
+  // We key on the primitive length to keep the dep list stable.
+  const queueLength = queue?.queue.length ?? null;
   useEffect(() => {
-    if (modalOpen && queue && queue.queue.length === 0) {
+    if (modalOpen && queueLength === 0) {
       setModalOpen(false);
+      router.push("/review");
     }
-  }, [modalOpen, queue]);
+  }, [modalOpen, queueLength, router]);
 
   const hasBrands = (pending?.brands.length ?? 0) > 0;
 
@@ -238,6 +288,16 @@ export function ReviewClient() {
         </>
       )}
 
+      {activeBrandId && (queueLoading || queue || queueError) && (
+        <ReviewGallery
+          queue={queue?.queue ?? []}
+          loading={queueLoading}
+          error={queueError}
+          onTileClick={handleTileClick}
+          onRetry={handleQueueRetry}
+        />
+      )}
+
       {queue && (
         <ReviewModal
           open={modalOpen && queue.queue.length > 0}
@@ -248,6 +308,116 @@ export function ReviewClient() {
           onClose={closeModal}
         />
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReviewGallery — co-located, pure-presentational sub-component.
+// Owns no state. Renders one of four branches: error, initial-load skeleton,
+// empty state, or the responsive grid of ReviewTiles (with a subtle dim during
+// refetch). Visual language matches the brand-cards "All clear" treatment
+// above so the page reads as one surface.
+// ---------------------------------------------------------------------------
+
+interface ReviewGalleryProps {
+  queue: ReviewQueueItem[];
+  loading: boolean;
+  error: boolean;
+  onTileClick: (index: number) => void;
+  onRetry: () => void;
+}
+
+function ReviewGallery({
+  queue,
+  loading,
+  error,
+  onTileClick,
+  onRetry,
+}: ReviewGalleryProps) {
+  // Error wins over loading: if the last fetch failed, show the retry card
+  // even while the next attempt is in flight (the loading branch will take
+  // over once the user clicks retry — handleQueueRetry clears error first).
+  if (error) {
+    return (
+      <Card data-slot="review-gallery-error" role="alert">
+        <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+          <AlertTriangle
+            className="size-10 text-destructive"
+            aria-hidden
+          />
+          <div className="space-y-1">
+            <p className="font-heading text-base font-medium text-foreground">
+              Couldn&apos;t load this brand&apos;s queue.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Something went wrong fetching the items. Try again?
+            </p>
+          </div>
+          <Button onClick={onRetry}>
+            <RotateCcw aria-hidden />
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Initial load — no queue data yet. Show the skeleton grid so the page
+  // doesn't collapse to nothing while the first fetch is in flight.
+  if (loading && queue.length === 0) {
+    return <ReviewGallerySkeleton />;
+  }
+
+  // Empty (resolved): brand exists but has nothing pending.
+  if (queue.length === 0) {
+    return (
+      <Card data-slot="review-gallery-empty">
+        <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+          <CheckCircle2
+            className="size-10 text-muted-foreground"
+            aria-hidden
+          />
+          <div className="space-y-1">
+            <p className="font-heading text-base font-medium text-foreground">
+              All clear — nothing pending for this brand.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Pick another brand from the list above to keep triaging.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            render={<Link href="/review" />}
+            nativeButton={false}
+          >
+            Back to brands
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Populated grid. Subtle dim during refetch — keeps the user oriented
+  // instead of ripping the grid out from under them. (Mirrors the library
+  // pattern at library-client.tsx:367-372.)
+  return (
+    <div
+      data-slot="review-gallery"
+      className={cn(
+        "grid grid-cols-2 gap-3 transition-opacity duration-150 motion-reduce:transition-none sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5",
+        loading && "opacity-70"
+      )}
+      aria-busy={loading || undefined}
+    >
+      {queue.map((item, index) => (
+        <ReviewTile
+          key={item.id}
+          item={item}
+          index={index}
+          onActivate={onTileClick}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/review-tile.tsx
+++ b/src/components/review-tile.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import { ImageOff, TriangleAlert, Video } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { type ReviewQueueItem } from "@/components/review-modal";
+
+// Re-export so callers can import the tile + the type from one module.
+export type { ReviewQueueItem };
+
+interface ReviewTileProps {
+  item: ReviewQueueItem;
+  index: number;
+  onActivate: (index: number) => void;
+}
+
+export function ReviewTile({ item, index, onActivate }: ReviewTileProps) {
+  const authorLabel =
+    item.author.name?.trim() ||
+    item.author.email?.split("@")[0] ||
+    "Unknown member";
+  const [imgFailed, setImgFailed] = useState(false);
+  const initials = (() => {
+    const parts = authorLabel.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  })();
+
+  return (
+    <button
+      type="button"
+      onClick={() => onActivate(index)}
+      data-slot="review-tile"
+      data-index={index}
+      aria-label={`Open review item ${index + 1}`}
+      className={cn(
+        "group/tile relative overflow-hidden rounded-xl bg-muted text-left",
+        "ring-1 ring-foreground/10",
+        "transition-[transform,box-shadow] duration-150 ease-out",
+        "hover:-translate-y-0.5 hover:shadow-lg hover:ring-primary/40",
+        "active:translate-y-px",
+        "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/60",
+        "motion-reduce:transition-none motion-reduce:hover:translate-y-0",
+        "motion-reduce:active:translate-y-0"
+      )}
+    >
+      <div className="relative aspect-square">
+        {imgFailed ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <ImageOff className="size-8 text-muted-foreground/40" aria-hidden />
+          </div>
+        ) : (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={item.thumbnailUrl}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+            decoding="async"
+            onError={() => setImgFailed(true)}
+          />
+        )}
+
+        {/* Top-left: media-type indicator (image is implicit, video gets a chip) */}
+        {item.mediaType === "video" && (
+          <div className="absolute left-2 top-2">
+            <Badge
+              variant="secondary"
+              className="gap-1 bg-background/85 text-foreground ring-1 ring-foreground/15 backdrop-blur-sm"
+            >
+              <Video className="size-3" aria-hidden />
+              Video
+            </Badge>
+          </div>
+        )}
+
+        {/* Top-right: brand-kit-overridden warning marker (icon-only to avoid colliding
+            with the Video badge at small breakpoints). Full text moves into the
+            prompt overlay below so triagers still see it on hover/focus. */}
+        {item.brandKitOverridden && (
+          <span
+            role="img"
+            aria-label="Brand kit overridden"
+            className="absolute right-2 top-2 inline-flex items-center justify-center rounded border border-amber-500/40 bg-amber-500/10 p-1 text-amber-700 backdrop-blur-sm dark:text-amber-300"
+          >
+            <TriangleAlert className="size-3" aria-hidden />
+          </span>
+        )}
+
+        {/* Bottom-right: author avatar (matches CreatorAvatar pattern in library-client) */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                className="absolute bottom-2 right-2 inline-flex rounded-full ring-2 ring-background/80"
+                aria-label={`${authorLabel} submitted this asset`}
+              >
+                <Avatar size="sm" className="size-6">
+                  {item.author.image ? (
+                    <AvatarImage src={item.author.image} alt="" />
+                  ) : null}
+                  <AvatarFallback className="text-[10px]">
+                    {initials}
+                  </AvatarFallback>
+                </Avatar>
+              </span>
+            }
+          />
+          <TooltipContent>{authorLabel} submitted this asset</TooltipContent>
+        </Tooltip>
+
+        {/* Prompt overlay — visible on hover/focus */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/75 via-black/20 to-transparent p-3 opacity-0 transition-opacity duration-150 group-hover/tile:opacity-100 group-focus-visible/tile:opacity-100">
+          {item.brandKitOverridden && (
+            <p className="text-[10px] font-medium text-amber-300/95">
+              Brand kit overridden
+            </p>
+          )}
+          <p className="line-clamp-1 text-xs font-medium text-white/95">
+            {item.prompt}
+          </p>
+          <p className="mt-0.5 text-[10px] text-white/70">{authorLabel}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton — 12 placeholder tiles in the same grid layout as ReviewGallery.
+// Co-located here so the gallery can import a single module.
+// ---------------------------------------------------------------------------
+
+export function ReviewGallerySkeleton() {
+  return (
+    <div
+      data-slot="review-gallery-skeleton"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+      aria-busy="true"
+      aria-label="Loading review queue"
+    >
+      {Array.from({ length: 12 }).map((_, i) => (
+        <Skeleton
+          key={i}
+          className="aspect-square w-full rounded-xl ring-1 ring-foreground/10"
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -17,8 +17,6 @@ export const CHANGELOG: ChangelogEntry[] = [
   },
   {
     date: "2026-04-30",
-<<<<<<< HEAD
-=======
     title: "Faster image previews + pick your download size",
     bullets: [
       "Library and Gallery full-size previews now load a compressed WebP version — typically 90%+ smaller than the original, way faster on slow connections",
@@ -30,7 +28,6 @@ export const CHANGELOG: ChangelogEntry[] = [
   },
   {
     date: "2026-04-30",
->>>>>>> origin/main
     title: "Self-hosted Docker distribution",
     bullets: [
       "Self-host OpenCauldron with Docker — docker compose up -d and you're running",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,16 @@ export type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-04-30",
+    title: "Review queue opens into a gallery",
+    bullets: [
+      "Picking a brand on /review now shows a scannable gallery of pending assets — no more forced single-item modal flow",
+      "Click any tile (or press Enter on it) to open the existing review modal at that asset",
+      "Closing the modal returns you to the gallery; only the last asset reviewed pops back to the brand list",
+      "Loading, empty, and error states get tasteful Card treatments — including a Try again button if the queue fetch fails",
+    ],
+  },
+  {
+    date: "2026-04-30",
     title: "Self-hosted Docker distribution",
     bullets: [
       "Self-host OpenCauldron with Docker — docker compose up -d and you're running",


### PR DESCRIPTION
## Summary

- Picking a brand on `/review` now renders a responsive 2/3/4/5-col gallery of pending assets at `/review?brand=<id>` instead of auto-opening the modal at index 0
- Click or Enter on any tile opens the existing `ReviewModal` at that index — keyboard model (j/k/a/r/n/Esc) is unchanged
- Closing the modal returns you to the gallery; the URL stays at `?brand=<id>`. Only the last asset reviewed pops back to the brand list
- Loading shows a 12-tile skeleton, empty queue shows an "All clear" Card, fetch failure shows a retry Card. Refetch keeps existing tiles dimmed (`aria-busy`) instead of replacing them with skeletons
- Focus is restored to the surviving tile after approve/reject so keyboard reviewers stay in flow
- Closes #39 (Fern's request — "open into a gallery view so we can quickly triage which ones are best for the campaign")

## What's NOT changed
- `src/components/review-modal.tsx` — zero diff (verified)
- `/api/reviews/queue/[brandId]` response shape — unchanged
- `/api/reviews/pending` — unchanged

## Pipeline note
First feature shipped through the full Studio Feedback Pipeline: **Loom → triage → GH issue #39 → spec → build → PR**.

## Test plan
- [x] US1 — pick a brand, see gallery (not modal)
- [x] US1 — gallery is responsive across breakpoints (2/3/4/5 cols)
- [x] US2 — click 3rd tile → modal opens at index 2
- [x] US2 — j/k inside modal walks the same queue the gallery rendered
- [x] US2 — Esc/X → modal closes, gallery still visible at `?brand=<id>`
- [x] US2 — approve last item in queue → modal closes AND URL pops to `/review`
- [x] US2 — focus lands on surviving tile after approve/reject
- [x] US3 — initial fetch shows skeleton; refetch dims existing tiles
- [x] US3 — empty queue shows "All clear" Card with "Back to brands"
- [x] US3 — fetch error shows error Card; "Try again" re-runs fetch
- [x] Broken thumbnails fall back to `ImageOff` icon (not blank squares)

QATester ran 50+ browser-driven assertions across US1, US2, US3 with seeded fixtures and forced error/empty states. Modal is untouched per `git diff src/components/review-modal.tsx`.

## Deferred
- US4 (localStorage view preference) — exceeds the spec's 30 LOC gate; filmstrip follow-up may render it moot
- Filmstrip + progress meter inside the modal — separate spec, scoped from a Designer proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)