### PR TITLE
Rebrand Cauldron → OpenCauldron + fix missing 0021 journal entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,7 @@ STORAGE_PROVIDER="local"
 # R2_ACCOUNT_ID=""
 # R2_ACCESS_KEY_ID=""
 # R2_SECRET_ACCESS_KEY=""
-# R2_BUCKET_NAME="cauldron"
+# R2_BUCKET_NAME="opencauldron"
 # R2_PUBLIC_URL=""
 
 # ============================================

--- a/drizzle/0022_rename_cauldron_brand.sql
+++ b/drizzle/0022_rename_cauldron_brand.sql
@@ -1,0 +1,24 @@
+-- Migration 0022 — Rebrand the seed `Cauldron` brand to `OpenCauldron`.
+--
+-- Idempotent and additive: only renames rows that still hold the legacy
+-- name+slug pair. Brand UUID is preserved, so every linked row (assets,
+-- brews, brand_members, etc.) keeps working without touching foreign keys.
+--
+-- Safe to run on:
+--   - Fresh DBs (no rows match → no-op)
+--   - DBs already on the new name (no rows match → no-op)
+--   - DBs where someone manually created an unrelated `OpenCauldron` brand
+--     in the same workspace (NOT EXISTS guard prevents the unique-index
+--     conflict from the partial index on (workspace_id, name)).
+UPDATE brands
+   SET name = 'OpenCauldron',
+       slug = 'opencauldron'
+ WHERE name = 'Cauldron'
+   AND slug = 'cauldron'
+   AND is_personal = false
+   AND NOT EXISTS (
+     SELECT 1 FROM brands b2
+      WHERE b2.workspace_id = brands.workspace_id
+        AND b2.name = 'OpenCauldron'
+        AND b2.is_personal = false
+   );

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,20 @@
       "when": 1777993109000,
       "tag": "0020_asset_threads_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778079509000,
+      "tag": "0021_thread_storage_counter",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1778165909000,
+      "tag": "0022_rename_cauldron_brand",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/revert-migration.ts
+++ b/scripts/revert-migration.ts
@@ -68,7 +68,7 @@ async function main() {
     await pool.query(`
       DELETE FROM brand_members;
       DELETE FROM brands WHERE is_personal = true;
-      DELETE FROM brands WHERE name IN ('Taboo Grow','GIDDI','Cauldron')
+      DELETE FROM brands WHERE name IN ('Taboo Grow','GIDDI','Cauldron','OpenCauldron')
         AND workspace_id = (SELECT id FROM workspaces WHERE slug = 'taboogrow');
       DELETE FROM workspace_members;
       DELETE FROM workspaces WHERE slug = 'taboogrow';

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -135,7 +135,7 @@ async function main() {
       accountId: () => p.text({ message: "R2 Account ID" }),
       accessKeyId: () => p.text({ message: "R2 Access Key ID" }),
       secretAccessKey: () => p.text({ message: "R2 Secret Access Key" }),
-      bucketName: () => p.text({ message: "R2 Bucket Name", placeholder: "cauldron", defaultValue: "cauldron" }),
+      bucketName: () => p.text({ message: "R2 Bucket Name", placeholder: "opencauldron", defaultValue: "opencauldron" }),
     });
     if (p.isCancel(r2)) cancelled();
     r2Config = r2;

--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -8,7 +8,7 @@
  *   pnpm tsx scripts/verify-migration.ts --smoke-public-slugs=https://studio.taboogrow.com
  *
  * Hard assertions:
- *   - Three seed brands (`Taboo Grow`, `GIDDI`, `Cauldron`) exist exactly once
+ *   - Three seed brands (`Taboo Grow`, `GIDDI`, `OpenCauldron`) exist exactly once
  *     each in the bootstrap workspace (`taboogrow`).
  *   - Personal-brand count equals workspace_member count.
  *   - No orphan brews (`brand_id IS NULL`).
@@ -83,11 +83,11 @@ async function main() {
     if (wsId) {
       const { rows: seedRows } = await pool.query<{ name: string; cnt: number }>(
         `SELECT name, COUNT(*)::int AS cnt FROM brands
-          WHERE workspace_id = $1 AND name IN ('Taboo Grow','GIDDI','Cauldron')
+          WHERE workspace_id = $1 AND name IN ('Taboo Grow','GIDDI','OpenCauldron')
           GROUP BY name`,
         [wsId]
       );
-      const want = ["Taboo Grow", "GIDDI", "Cauldron"];
+      const want = ["Taboo Grow", "GIDDI", "OpenCauldron"];
       for (const name of want) {
         const row = seedRows.find((r) => r.name === name);
         record(

--- a/src/app/(dashboard)/generate/generate-client.tsx
+++ b/src/app/(dashboard)/generate/generate-client.tsx
@@ -550,11 +550,11 @@ export function GenerateClient({
   useEffect(() => {
     if (!nsfwHydrated.current) {
       nsfwHydrated.current = true;
-      const stored = localStorage.getItem("cauldron-nsfw-loras");
+      const stored = localStorage.getItem("opencauldron-nsfw-loras");
       if (stored === "true") setNsfwEnabled(true);
       return;
     }
-    localStorage.setItem("cauldron-nsfw-loras", String(nsfwEnabled));
+    localStorage.setItem("opencauldron-nsfw-loras", String(nsfwEnabled));
   }, [nsfwEnabled]);
 
   // Clear LoRAs when switching to a model that doesn't support them

--- a/src/app/(dashboard)/loras/loras-client.tsx
+++ b/src/app/(dashboard)/loras/loras-client.tsx
@@ -173,11 +173,11 @@ export function LorasClient() {
   useEffect(() => {
     if (!nsfwHydrated.current) {
       nsfwHydrated.current = true;
-      const stored = localStorage.getItem("cauldron-nsfw-loras");
+      const stored = localStorage.getItem("opencauldron-nsfw-loras");
       if (stored === "true") setNsfwEnabled(true);
       return;
     }
-    localStorage.setItem("cauldron-nsfw-loras", String(nsfwEnabled));
+    localStorage.setItem("opencauldron-nsfw-loras", String(nsfwEnabled));
   }, [nsfwEnabled]);
 
   // Reset results when source changes

--- a/src/app/api/assets/[id]/download/route.ts
+++ b/src/app/api/assets/[id]/download/route.ts
@@ -91,12 +91,12 @@ export async function GET(
       return NextResponse.json({ error: "WebP not available" }, { status: 404 });
     }
     key = asset.webpR2Key;
-    filename = `cauldron-${id8}.webp`;
+    filename = `opencauldron-${id8}.webp`;
   } else {
     key = asset.r2Key;
     const fallbackMime = asset.mediaType === "video" ? "video/mp4" : null;
     const ext = extensionFor(asset.originalMimeType ?? fallbackMime);
-    filename = `cauldron-${id8}-original.${ext}`;
+    filename = `opencauldron-${id8}-original.${ext}`;
   }
 
   let object;

--- a/src/app/styleguide/page.tsx
+++ b/src/app/styleguide/page.tsx
@@ -486,7 +486,7 @@ function SidebarPreview() {
         <div className="flex items-center gap-3">
           <AppLogo size={36} />
           <div>
-            <p className="font-heading text-base font-bold" style={{ color: "var(--sidebar-foreground)" }}>Cauldron</p>
+            <p className="font-heading text-base font-bold" style={{ color: "var(--sidebar-foreground)" }}>OpenCauldron</p>
             <p className="text-[10px] font-medium uppercase tracking-widest" style={{ color: "var(--muted-foreground)" }}>
               Studio
             </p>
@@ -716,7 +716,7 @@ export default function StyleguidePage() {
                 WebkitTextFillColor: "transparent",
               }}
             >
-              Cauldron Design System
+              OpenCauldron Design System
             </h1>
             <p className="mt-3 max-w-md text-sm leading-relaxed" style={{ color: "var(--muted-foreground)" }}>
               Proposed magical indigo theme with wand identity.
@@ -977,7 +977,7 @@ export default function StyleguidePage() {
           style={{ borderColor: "var(--border)" }}
         >
           <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>
-            Style Guide — Cauldron Studio
+            Style Guide — OpenCauldron
           </p>
         </footer>
       </div>

--- a/src/components/library/asset-download-button.tsx
+++ b/src/components/library/asset-download-button.tsx
@@ -23,8 +23,8 @@
  * conditional class structure below.
  *
  * Telemetry: every successful download fires `asset_downloaded` via
- * `trackEvent` (FR-011). Filenames follow `cauldron-{id8}.webp` for WebP and
- * `cauldron-{id8}-original.{ext}` for originals (FR-010).
+ * `trackEvent` (FR-011). Filenames follow `opencauldron-{id8}.webp` for WebP and
+ * `opencauldron-{id8}-original.{ext}` for originals (FR-010).
  */
 
 import * as React from "react";
@@ -110,7 +110,7 @@ function extensionFor(mimeType: string | null): string {
   return slash >= 0 ? lower.slice(slash + 1).split(/[+;]/)[0] : "bin";
 }
 
-/** First 8 chars of the asset id — matches the `cauldron-{id8}` filename scheme. */
+/** First 8 chars of the asset id — matches the `opencauldron-{id8}` filename scheme. */
 function id8(id: string): string {
   return id.slice(0, 8);
 }
@@ -164,7 +164,7 @@ export function AssetDownloadButton({
     if (!asset.webpUrl || !asset.webpFileSize) return;
     triggerDownload(
       downloadUrlFor(asset.id, "webp"),
-      `cauldron-${id8(asset.id)}.webp`
+      `opencauldron-${id8(asset.id)}.webp`
     );
     trackEvent("asset_downloaded", {
       format: "webp",
@@ -177,7 +177,7 @@ export function AssetDownloadButton({
   const handleDownloadOriginal = React.useCallback(() => {
     triggerDownload(
       downloadUrlFor(asset.id, "original"),
-      `cauldron-${id8(asset.id)}-original.${originalExt}`
+      `opencauldron-${id8(asset.id)}-original.${originalExt}`
     );
     trackEvent("asset_downloaded", {
       format: "original",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,16 @@ export type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: "2026-05-01",
+    title: "Now called OpenCauldron",
+    bullets: [
+      "The studio is officially OpenCauldron — the styleguide, sidebar branding, and downloaded filenames all carry the new name",
+      "Saved files now download as opencauldron-{id}.webp / opencauldron-{id}-original.{ext} (was cauldron-…)",
+      "The seed brand previously named \"Cauldron\" is renamed to \"OpenCauldron\" in place — same brand, new label, no asset moves",
+      "Self-host setup wizard defaults the R2 bucket to opencauldron",
+    ],
+  },
+  {
+    date: "2026-05-01",
     title: "Filmstrip in the review modal",
     bullets: [
       "Inside the review modal, a horizontal filmstrip rail at the bottom now shows what's coming next and what just passed — no more guessing where you are in the queue",

--- a/tests/integration/migration.test.ts
+++ b/tests/integration/migration.test.ts
@@ -109,7 +109,7 @@ describe.skipIf(!enabled)("agency-DAM migration", () => {
 
     const brandsCount = await pool.query<{ name: string; cnt: string }>(
       `SELECT name, COUNT(*) AS cnt FROM brands
-        WHERE workspace_id = $1 AND name IN ('Taboo Grow','GIDDI','Cauldron')
+        WHERE workspace_id = $1 AND name IN ('Taboo Grow','GIDDI','OpenCauldron')
         GROUP BY name`,
       [ws.rows[0].id]
     );


### PR DESCRIPTION
## Summary

- Rebrands the seed `Cauldron` brand to `OpenCauldron` at the DB level via idempotent migration `0022_rename_cauldron_brand` (safe on fresh, already-renamed, and conflict DBs).
- Sweeps every user-visible "Cauldron" string: download filenames now `opencauldron-{id}.webp`, styleguide + sidebar branding, seed-brand assertions in `verify-migration.ts`, the self-host setup wizard's default R2 bucket, plus a "What's New" entry so users see it.
- **Fixes a journal bug**: the merged threads PR shipped `0021_thread_storage_counter.sql` but never registered it in `drizzle/meta/_journal.json` — drizzle-kit was unable to apply it. This PR inserts idx 21 for the threads counter and registers the new rebrand migration at idx 22.

## Why this matters

Without the journal fix, the `THREADS_ENABLED` flag can't safely be flipped on in production — the underlying table (`thread_storage_counter`) wouldn't exist. This unblocks the threads rollout.

## Test plan

- [ ] `pnpm db:migrate` against a fresh local DB → 0021 + 0022 both apply cleanly
- [ ] `pnpm db:migrate` against a DB already on the post-0020 state → only 0021 + 0022 run
- [ ] `pnpm tsx scripts/verify-migration.ts` → seed brand assertion passes with `OpenCauldron`
- [ ] Visit `/library` → download an asset → file is named `opencauldron-{id}.webp`
- [ ] Visit `/styleguide` → branding shows "OpenCauldron"

## Rollout note

After this merges and prod migrations apply, set `THREADS_ENABLED=true` on the `taboo-studio` Vercel production env to enable the threads UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)