### PR TITLE
feat: bulk actions for Library, Gallery, and Brand Gallery

### DIFF
--- a/src/app/(dashboard)/gallery/gallery-client.tsx
+++ b/src/app/(dashboard)/gallery/gallery-client.tsx
@@ -66,6 +66,15 @@ import {
 import { BrandMark } from "@/components/brand-mark";
 import { AssetDownloadButton } from "@/components/library/asset-download-button";
 import { ThreadPanel } from "@/components/threads/thread-panel";
+import { useBulkSelection } from "@/components/bulk/use-bulk-selection";
+import { BulkSelectCheckbox } from "@/components/bulk/bulk-select-checkbox";
+import {
+  BulkActionBar,
+  type BulkActionKind,
+  type BulkBarAsset,
+} from "@/components/bulk/bulk-action-bar";
+import type { BulkCampaignOption } from "@/components/bulk/bulk-campaign-picker";
+import { cn } from "@/lib/utils";
 
 const PROVIDER_LABELS: Record<string, string> = {
   google: "Gemini",
@@ -265,6 +274,14 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
   const [dateTo, setDateTo] = useState(() => searchParams.get("to") ?? "");
 
   const observerRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  // Campaigns for the bulk action picker. Loaded per visible brand on demand
+  // so a workspace with hundreds of campaigns doesn't pay the cost up-front.
+  const [campaignOptions, setCampaignOptions] = useState<BulkCampaignOption[]>(
+    []
+  );
+  const loadedCampaignBrandsRef = useRef<Set<string>>(new Set());
 
   // Sync filter state to the URL (replace, not push, so each keystroke doesn't
   // bloat history). useEffect dependency tracks the canonical filter set.
@@ -364,6 +381,90 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
     return () => observer.disconnect();
   }, [nextCursor, loadingMore, loadMore]);
 
+  // Bulk selection wiring. The hook prunes vanished ids automatically when
+  // `assets` changes (filter swap, cursor refetch).
+  const bulkSelection = useBulkSelection<GalleryAsset>(
+    assets,
+    (a) => a.id,
+    { containerRef: gridRef }
+  );
+  const {
+    selectedIds: bulkSelectedIds,
+    isSelected: bulkIsSelected,
+    toggle: bulkToggle,
+    clear: bulkClear,
+    count: bulkCount,
+  } = bulkSelection;
+
+  // Clear selection on filter changes — the in-flight or next refetch may
+  // not include the currently-selected ids.
+  useEffect(() => {
+    bulkClear();
+    // Intentionally only reactive to filter inputs, not the clear function.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    modelFilter,
+    mediaTypeFilter,
+    statusFilter,
+    brandFilter,
+    searchQuery,
+    dateFrom,
+    dateTo,
+  ]);
+
+  // On-demand campaign load for the picker. The picker only acts on a
+  // single-brand selection, so we lazily fetch each brand's campaigns the
+  // first time we see it.
+  useEffect(() => {
+    const seen = loadedCampaignBrandsRef.current;
+    const needed = new Set<string>();
+    for (const id of bulkSelectedIds) {
+      const a = assets.find((x) => x.id === id);
+      if (a?.brandId && !seen.has(a.brandId)) needed.add(a.brandId);
+    }
+    if (needed.size === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      const fetched = await Promise.all(
+        Array.from(needed).map(async (brandId) => {
+          try {
+            const res = await fetch(
+              `/api/campaigns?brandId=${encodeURIComponent(brandId)}`
+            );
+            if (!res.ok) return [] as BulkCampaignOption[];
+            const data = (await res.json()) as Array<{
+              id: string;
+              name: string;
+            }>;
+            return data.map((c) => ({
+              id: c.id,
+              name: c.name,
+              brandId,
+            }));
+          } catch {
+            return [] as BulkCampaignOption[];
+          }
+        })
+      );
+      if (cancelled) return;
+      for (const id of needed) seen.add(id);
+      const flat = fetched.flat();
+      if (flat.length > 0) {
+        setCampaignOptions((prev) => {
+          const byKey = new Map(
+            prev.map((c) => [`${c.brandId}:${c.id}`, c] as const)
+          );
+          for (const c of flat) byKey.set(`${c.brandId}:${c.id}`, c);
+          return Array.from(byKey.values());
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bulkSelectedIds, assets]);
+
   const handleDelete = async (id: string) => {
     setDeleting(true);
     try {
@@ -454,6 +555,77 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
   };
 
   const isAdmin = me.role === "owner" || me.role === "admin";
+
+  const selectedBulkAssets = useMemo<BulkBarAsset[]>(
+    () =>
+      assets
+        .filter((a) => bulkSelectedIds.has(a.id))
+        .map((a) => ({
+          id: a.id,
+          brandId: a.brandId,
+          // GalleryAsset.status is nullable for legacy rows; the action bar
+          // treats null as ineligible for state-changing actions, which is
+          // correct.
+          status: a.status,
+          userId: a.userId,
+        })),
+    [assets, bulkSelectedIds]
+  );
+
+  const bulkBrandOptions = useMemo(
+    () =>
+      allBrands
+        .filter((b) => !b.isPersonal)
+        .map((b) => ({
+          id: b.id,
+          name: b.name,
+          color: b.color,
+          isPersonal: b.isPersonal ?? false,
+          logoUrl: b.logoUrl ?? null,
+          ownerImage: b.ownerImage ?? null,
+        })),
+    [allBrands]
+  );
+
+  const handleBulkApplied = useCallback(
+    (kind: BulkActionKind, succeeded: string[]) => {
+      if (succeeded.length === 0) return;
+      const succSet = new Set(succeeded);
+      if (kind === "delete") {
+        setAssets((prev) => prev.filter((a) => !succSet.has(a.id)));
+      } else {
+        // Refetch the current view so reassign / transition / campaign
+        // changes reconcile from the server.
+        fetch(`/api/assets?${buildQuery()}`)
+          .then(async (res) => {
+            if (!res.ok) return null;
+            return await res.json();
+          })
+          .then((data) => {
+            if (!data) return;
+            let filtered = data.assets as GalleryAsset[];
+            if (dateFrom) {
+              const from = new Date(dateFrom);
+              filtered = filtered.filter(
+                (a) => new Date(a.createdAt) >= from
+              );
+            }
+            if (dateTo) {
+              const to = new Date(dateTo);
+              to.setHours(23, 59, 59, 999);
+              filtered = filtered.filter((a) => new Date(a.createdAt) <= to);
+            }
+            setAssets(filtered);
+            setNextCursor(data.nextCursor ?? null);
+          })
+          .catch(() => {
+            /* non-fatal */
+          });
+      }
+      bulkClear();
+    },
+    [buildQuery, bulkClear, dateFrom, dateTo]
+  );
 
   /** Brands the caller is `creator+` on (admin override sees every brand). */
   const reassignDestinations = useMemo(() => {
@@ -836,12 +1008,19 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
 
       {/* Grid */}
       {!loading && assets.length > 0 && (
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        <div
+          ref={gridRef}
+          tabIndex={-1}
+          className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4"
+        >
           {assets.map((asset) => (
             <GalleryCard
               key={asset.id}
               asset={asset}
               onClick={() => setSelectedAsset(asset)}
+              selected={bulkIsSelected(asset.id)}
+              onToggle={(event) => bulkToggle(asset.id, event)}
+              selectionActive={bulkCount > 0}
             />
           ))}
         </div>
@@ -1451,6 +1630,20 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
           </DialogContent>
         ) : null}
       </Dialog>
+
+      <BulkActionBar
+        assets={selectedBulkAssets}
+        viewer={{
+          userId: me.userId,
+          workspaceRole: me.role,
+          brandRoles: me.brandRoles,
+        }}
+        brandOptions={bulkBrandOptions}
+        campaignOptions={campaignOptions}
+        lockedBrandId={lockedBrandId}
+        onClear={bulkClear}
+        onApplied={handleBulkApplied}
+      />
     </div>
   );
 }
@@ -1462,16 +1655,54 @@ export function GalleryClient({ lockedBrandId, viewer }: GalleryClientProps) {
 function GalleryCard({
   asset,
   onClick,
+  selected,
+  onToggle,
+  selectionActive,
 }: {
   asset: GalleryAsset;
   onClick: () => void;
+  selected: boolean;
+  onToggle: (event: { shiftKey?: boolean }) => void;
+  selectionActive: boolean;
 }) {
   const isVideo = asset.mediaType === "video";
 
+  // Card root is a div with role="button" — the card hosts a child checkbox
+  // that itself is a <button>. Nesting buttons is invalid HTML, so we wire
+  // Enter/Space + click manually. Shift-click and selection-active clicks
+  // toggle the bulk-select state instead of opening the lightbox.
   return (
-    <button
-      onClick={onClick}
-      className="group relative overflow-hidden rounded-lg bg-muted text-left cursor-pointer transition-all hover:ring-2 hover:ring-ring/50 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    <div
+      role="button"
+      tabIndex={0}
+      data-selected={selected || undefined}
+      onClick={(e) => {
+        if (e.shiftKey || selectionActive) {
+          e.preventDefault();
+          onToggle({ shiftKey: e.shiftKey });
+          return;
+        }
+        onClick();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          if (e.shiftKey) {
+            onToggle({ shiftKey: true });
+          } else if (selectionActive) {
+            onToggle({});
+          } else {
+            onClick();
+          }
+        }
+      }}
+      aria-pressed={selected}
+      className={cn(
+        "group/card group relative overflow-hidden rounded-lg bg-muted text-left cursor-pointer transition-all",
+        "hover:ring-2 hover:ring-ring/50 hover:-translate-y-0.5 hover:shadow-lg",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        selected && "ring-2 ring-primary/70"
+      )}
     >
       <div className="aspect-square relative">
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -1480,6 +1711,12 @@ function GalleryCard({
           alt={asset.prompt}
           className="h-full w-full object-cover"
           loading="lazy"
+        />
+
+        <BulkSelectCheckbox
+          checked={selected}
+          onToggle={onToggle}
+          alwaysVisible={selectionActive}
         />
 
         {/* Brand tag — top-left, single brand from FK (FR-009). */}
@@ -1568,7 +1805,7 @@ function GalleryCard({
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/app/(dashboard)/generate/generate-client.tsx
+++ b/src/app/(dashboard)/generate/generate-client.tsx
@@ -81,6 +81,7 @@ import {
 import type { promptModifiers as PromptModifiersType } from "@/providers/prompt-improver";
 import { LoraBrowser } from "./lora-browser";
 import { PromptToolbar } from "./prompt-toolbar";
+import { CampaignPicker } from "@/components/asset/campaign-picker";
 
 interface GenerateClientProps {
   imageModels: ModelInfo[];
@@ -2384,6 +2385,30 @@ export function GenerateClient({
                   );
                 })}
               </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Campaign tagger — only renders when the active brand is non-personal
+            AND the viewer is a brand creator (creator+, brand manager, or
+            workspace admin/owner). Picker hides itself otherwise. */}
+        {activeBrand && !activeBrand.isPersonal && (
+          <Card>
+            <CardContent className="px-4 py-4">
+              <CampaignPicker
+                assetId={generatedAsset.id}
+                brandId={activeBrand.id}
+                campaigns={
+                  activeCampaignId
+                    ? (() => {
+                        const opt = campaignOptions.find(
+                          (c) => c.id === activeCampaignId
+                        );
+                        return opt ? [{ id: opt.id, name: opt.name }] : [];
+                      })()
+                    : []
+                }
+              />
             </CardContent>
           </Card>
         )}

--- a/src/app/(dashboard)/library/detail-panel.tsx
+++ b/src/app/(dashboard)/library/detail-panel.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
-  Check,
-  ChevronDown,
   Hash,
   Loader2,
-  Megaphone,
   MessageSquareText,
   Pin,
-  Plus,
   Sparkles,
   Trash2,
   Wand2,
@@ -29,13 +25,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Sheet,
   SheetContent,
@@ -54,6 +44,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { LibraryAsset, LibraryViewer } from "./library-client";
 import { ThreadPanel } from "@/components/threads/thread-panel";
+import { CampaignPicker } from "@/components/asset/campaign-picker";
 
 export interface LibraryBrand {
   id: string;
@@ -241,13 +232,15 @@ function DetailPanelBody({
           emptyHint="Tags help you find this asset later — add a few descriptors."
         />
 
-        {/* Campaigns — typeahead Combobox sourced from
-            /api/campaigns?brandId=<asset.brandId>. Personal-brand assets
-            (brandId === null) skip the picker entirely; they don't support
-            campaigns. */}
+        {/* Campaigns — only renders for brand creators (creator+, brand
+            manager, workspace admin/owner). Hidden entirely for viewers and
+            for personal-brand assets. */}
         <CampaignPicker
-          asset={asset}
+          assetId={asset.id}
+          brandId={asset.brandId}
+          campaigns={asset.campaigns}
           onChange={(next) => onAssetUpdate({ ...asset, campaigns: next })}
+          hideWhenEmptyBrand={false}
         />
 
         <Separator />
@@ -786,407 +779,3 @@ function formatRelativeDate(iso: string): string {
   });
 }
 
-// ---------------------------------------------------------------------------
-// CampaignPicker — typeahead Combobox over the asset's brand-scoped campaign
-// list. Selected values are uuids; chip labels are names. Includes an inline
-// "+ New campaign" affordance that opens a small create dialog scoped to the
-// asset's brand. Read /api/campaigns?brandId=<asset.brandId>; PATCH
-// /api/library/<id> with `{ campaigns: uuid[] }` (full replace).
-// ---------------------------------------------------------------------------
-
-interface CampaignOption {
-  id: string;
-  name: string;
-}
-
-function CampaignPicker({
-  asset,
-  onChange,
-}: {
-  asset: LibraryAsset;
-  onChange: (next: { id: string; name: string }[]) => void;
-}) {
-  const [options, setOptions] = useState<CampaignOption[] | null>(null);
-  const [open, setOpen] = useState(false);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const [pendingId, setPendingId] = useState<string | null>(null);
-
-  const brandId = asset.brandId;
-
-  // Lazy-load campaigns when the popover opens for the first time. Re-fetch
-  // when the asset's brand changes (e.g. user reassigned the brand elsewhere
-  // and reopens the panel).
-  useEffect(() => {
-    if (!open || !brandId) return;
-    let cancelled = false;
-    fetch(`/api/campaigns?brandId=${brandId}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (cancelled || !data) return;
-        const rows = Array.isArray(data.campaigns) ? data.campaigns : [];
-        setOptions(
-          rows.map((c: { id: string; name: string }) => ({
-            id: c.id,
-            name: c.name,
-          }))
-        );
-      })
-      .catch(() => {
-        if (!cancelled) setOptions([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, brandId]);
-
-  const handleToggle = async (option: CampaignOption) => {
-    const exists = asset.campaigns.some((c) => c.id === option.id);
-    const next = exists
-      ? asset.campaigns.filter((c) => c.id !== option.id)
-      : [...asset.campaigns, { id: option.id, name: option.name }];
-    setPendingId(option.id);
-    const ok = await patchAsset(asset.id, {
-      campaigns: next.map((c) => c.id),
-    });
-    setPendingId(null);
-    if (!ok) {
-      toast.error("Couldn't update campaigns. Try again.");
-      return;
-    }
-    onChange(next);
-  };
-
-  const handleRemoveChip = async (campaignId: string) => {
-    const next = asset.campaigns.filter((c) => c.id !== campaignId);
-    setPendingId(campaignId);
-    const ok = await patchAsset(asset.id, {
-      campaigns: next.map((c) => c.id),
-    });
-    setPendingId(null);
-    if (!ok) {
-      toast.error("Couldn't remove campaign. Try again.");
-      return;
-    }
-    onChange(next);
-  };
-
-  const handleCreated = (campaign: CampaignOption) => {
-    setOptions((prev) => (prev ? [...prev, campaign] : [campaign]));
-    // Auto-attach the new campaign to this asset.
-    const next = [...asset.campaigns, { id: campaign.id, name: campaign.name }];
-    setPendingId(campaign.id);
-    patchAsset(asset.id, { campaigns: next.map((c) => c.id) }).then((ok) => {
-      setPendingId(null);
-      if (ok) onChange(next);
-    });
-  };
-
-  // Personal-brand assets (or anything without a brand) can't have campaigns.
-  // Render a quiet hint instead of a broken picker.
-  if (!brandId) {
-    return (
-      <div className="flex flex-col gap-2">
-        <Label>Campaigns</Label>
-        <p className="text-xs text-muted-foreground">
-          This asset isn&apos;t on a brand, so it can&apos;t be added to a
-          campaign.
-        </p>
-      </div>
-    );
-  }
-
-  const trimmed = search.trim().toLowerCase();
-  const filtered = (options ?? []).filter((c) =>
-    trimmed.length === 0 ? true : c.name.toLowerCase().includes(trimmed)
-  );
-
-  return (
-    <div className="flex flex-col gap-2">
-      <Label>Campaigns</Label>
-
-      {asset.campaigns.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {asset.campaigns.map((c) => (
-            <button
-              key={c.id}
-              type="button"
-              onClick={() => handleRemoveChip(c.id)}
-              disabled={pendingId === c.id}
-              className={cn(
-                "group/chip inline-flex h-6 items-center gap-1 rounded-md bg-primary/10 px-2 text-xs font-medium text-primary ring-1 ring-primary/25 transition-colors",
-                "hover:bg-destructive/10 hover:text-destructive hover:ring-destructive/30",
-                "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
-                pendingId === c.id && "opacity-60"
-              )}
-              aria-label={`Remove campaign ${c.name}`}
-            >
-              <Megaphone
-                className="size-3 text-current opacity-70"
-                aria-hidden
-              />
-              <span>{c.name}</span>
-              {pendingId === c.id ? (
-                <Loader2 className="size-3 animate-spin" aria-hidden />
-              ) : (
-                <X
-                  className="size-3 opacity-60 transition-opacity group-hover/chip:opacity-100"
-                  aria-hidden
-                />
-              )}
-            </button>
-          ))}
-        </div>
-      ) : (
-        <p className="text-xs text-muted-foreground">
-          Group assets by campaign to keep launches organized.
-        </p>
-      )}
-
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="justify-between gap-2"
-              aria-label="Add to campaign"
-            >
-              <span className="text-muted-foreground">Add to campaign…</span>
-              <ChevronDown
-                className="size-3.5 text-muted-foreground"
-                aria-hidden
-              />
-            </Button>
-          }
-        />
-        <PopoverContent align="start" className="w-72 p-0">
-          <div className="border-b border-border p-1">
-            <Input
-              autoFocus
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search campaigns…"
-              className="h-8 border-none bg-transparent px-2 text-sm shadow-none focus-visible:border-none focus-visible:ring-0"
-            />
-          </div>
-          <div className="max-h-64 overflow-y-auto p-1">
-            {options === null ? (
-              <div className="flex items-center justify-center py-4 text-xs text-muted-foreground">
-                <Loader2 className="size-3.5 animate-spin" aria-hidden />
-              </div>
-            ) : filtered.length === 0 ? (
-              <p className="px-2 py-3 text-center text-xs text-muted-foreground">
-                {trimmed
-                  ? "No matches."
-                  : "No campaigns yet on this brand."}
-              </p>
-            ) : (
-              <ul className="flex flex-col gap-0.5">
-                {filtered.map((c) => {
-                  const checked = asset.campaigns.some((x) => x.id === c.id);
-                  const busy = pendingId === c.id;
-                  return (
-                    <li key={c.id}>
-                      <button
-                        type="button"
-                        onClick={() => handleToggle(c)}
-                        disabled={busy}
-                        className={cn(
-                          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-                          "hover:bg-accent",
-                          checked && "bg-primary/10 text-primary",
-                          busy && "opacity-60"
-                        )}
-                      >
-                        <span
-                          aria-hidden
-                          className={cn(
-                            "flex size-4 items-center justify-center rounded-sm border",
-                            checked
-                              ? "border-primary bg-primary text-primary-foreground"
-                              : "border-foreground/25"
-                          )}
-                        >
-                          {checked && <Check className="size-3" aria-hidden />}
-                        </span>
-                        <Megaphone
-                          className="size-3.5 text-muted-foreground"
-                          aria-hidden
-                        />
-                        <span className="flex-1 truncate">{c.name}</span>
-                        {busy && (
-                          <Loader2
-                            className="size-3 animate-spin text-muted-foreground"
-                            aria-hidden
-                          />
-                        )}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-          <div className="border-t border-border p-1">
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                setCreateOpen(true);
-              }}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm",
-                "hover:bg-accent text-muted-foreground hover:text-foreground"
-              )}
-            >
-              <Plus className="size-3.5" aria-hidden />
-              New campaign
-            </button>
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      <CreateCampaignDialog
-        open={createOpen}
-        brandId={brandId}
-        onOpenChange={setCreateOpen}
-        onCreated={handleCreated}
-      />
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// CreateCampaignDialog — minimal name + description form. Mirrors the brand
-// campaigns admin (`brands/[slug]/campaigns/campaigns-client.tsx`) but inline
-// so the user doesn't have to leave the asset detail. Brand-scoped via the
-// `brandId` prop so the create POST is always anchored to the asset's brand.
-// ---------------------------------------------------------------------------
-
-function CreateCampaignDialog({
-  open,
-  brandId,
-  onOpenChange,
-  onCreated,
-}: {
-  open: boolean;
-  brandId: string;
-  onOpenChange: (open: boolean) => void;
-  onCreated: (campaign: { id: string; name: string }) => void;
-}) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [creating, setCreating] = useState(false);
-
-  // Reset on close — render-time pattern, no effect.
-  const [prevOpen, setPrevOpen] = useState(open);
-  if (open !== prevOpen) {
-    setPrevOpen(open);
-    if (!open) {
-      setName("");
-      setDescription("");
-    }
-  }
-
-  const handleCreate = async () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setCreating(true);
-    try {
-      const res = await fetch("/api/campaigns", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          brandId,
-          name: trimmed,
-          description: description.trim() || undefined,
-        }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        toast.error(
-          data.error === "campaign_name_collision"
-            ? "A campaign with that name already exists."
-            : data.error === "forbidden"
-            ? "You don't have permission to create campaigns on this brand."
-            : "Couldn't create campaign. Try again."
-        );
-        return;
-      }
-      const data = (await res.json()) as {
-        campaign: { id: string; name: string };
-      };
-      toast.success("Campaign created");
-      onCreated({ id: data.campaign.id, name: data.campaign.name });
-      onOpenChange(false);
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) onOpenChange(false);
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>New campaign</DialogTitle>
-          <DialogDescription>
-            Group assets under a launch, drop, or initiative.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="new-campaign-name">Name</Label>
-            <Input
-              id="new-campaign-name"
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Spring sale 2026"
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !creating && name.trim()) {
-                  e.preventDefault();
-                  handleCreate();
-                }
-              }}
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="new-campaign-desc">Description (optional)</Label>
-            <Textarea
-              id="new-campaign-desc"
-              rows={2}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </div>
-        </div>
-        <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => onOpenChange(false)}
-            disabled={creating}
-          >
-            Cancel
-          </Button>
-          <Button onClick={handleCreate} disabled={creating || !name.trim()}>
-            {creating ? (
-              <>
-                <Loader2 className="animate-spin" aria-hidden />
-                Creating…
-              </>
-            ) : (
-              "Create"
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}

--- a/src/app/(dashboard)/library/library-client.tsx
+++ b/src/app/(dashboard)/library/library-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   Archive,
@@ -41,6 +41,13 @@ import {
   type CampaignOption,
   type TagOption,
 } from "./filter-bar";
+import { useBulkSelection } from "@/components/bulk/use-bulk-selection";
+import { BulkSelectCheckbox } from "@/components/bulk/bulk-select-checkbox";
+import {
+  BulkActionBar,
+  type BulkActionKind,
+  type BulkBarAsset,
+} from "@/components/bulk/bulk-action-bar";
 import { SearchInput } from "./search-input";
 import {
   serializeLibraryQuery,
@@ -129,6 +136,12 @@ interface LibraryClientProps {
   viewer: LibraryViewer;
 }
 
+interface BulkViewerState {
+  userId: string | null;
+  workspaceRole: "owner" | "admin" | "member" | null;
+  brandRoles: Record<string, "brand_manager" | "creator" | "viewer">;
+}
+
 // ---------------------------------------------------------------------------
 // Outer container — owns the LibraryQueryProvider so every facet shares the
 // same URL-synced state. The inner <LibraryGridContainer> reads the query
@@ -199,6 +212,7 @@ function LibraryGridContainer({
   initialNextCursor,
   initialTotal,
   initialBrands,
+  facetCampaigns,
   viewer,
 }: LibraryClientProps) {
   const router = useRouter();
@@ -214,6 +228,43 @@ function LibraryGridContainer({
   const [loadingPage, setLoadingPage] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [brands, setBrands] = useState<LibraryBrand[]>(initialBrands);
+  const [bulkViewer, setBulkViewer] = useState<BulkViewerState>({
+    userId: viewer.id,
+    workspaceRole: null,
+    brandRoles: {},
+  });
+
+  // Hydrate the viewer's permissions for the action-bar eligibility hints.
+  // Server is the source of truth; this just dims buttons that have no
+  // chance of succeeding.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/me")
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        setBulkViewer({
+          userId: data?.userId ?? viewer.id,
+          workspaceRole: data?.role ?? null,
+          brandRoles: data?.brandRoles ?? {},
+        });
+      })
+      .catch(() => {
+        /* non-fatal — buttons stay generic */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [viewer.id]);
+
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const bulkSelection = useBulkSelection<LibraryAsset>(
+    items,
+    (a) => a.id,
+    { containerRef: gridRef }
+  );
+  const { selectedIds, isSelected, toggle, clear, count: bulkCount } =
+    bulkSelection;
 
   // Seed the first count immediately so the summary line doesn't flicker on
   // the initial render with filters that match the server-hydrated set.
@@ -236,6 +287,10 @@ function LibraryGridContainer({
     const next = searchParams.toString();
     if (next === lastQueryStringRef.current) return;
     lastQueryStringRef.current = next;
+    // Selection on a previous filter set shouldn't carry into a new one — the
+    // ids may not even appear in the new fetch. Clear before the network
+    // round-trip so the action bar doesn't flicker with stale state.
+    clear();
 
     let cancelled = false;
     setLoadingPage(true);
@@ -269,7 +324,7 @@ function LibraryGridContainer({
     return () => {
       cancelled = true;
     };
-  }, [searchParams, setResultsCount]);
+  }, [searchParams, setResultsCount, clear]);
 
   const loadMore = useCallback(
     async (cursor: string) => {
@@ -359,6 +414,69 @@ function LibraryGridContainer({
     setItems((prev) => prev.filter((it) => it.id !== id));
     setSelectedId((curr) => (curr === id ? null : curr));
   }, []);
+
+  const handleBulkApplied = useCallback(
+    (kind: BulkActionKind, succeeded: string[]) => {
+      if (succeeded.length === 0) return;
+      const succSet = new Set(succeeded);
+      if (kind === "delete") {
+        setItems((prev) => prev.filter((it) => !succSet.has(it.id)));
+      } else {
+        // For state-changing actions, the canonical truth lives server-side
+        // (status flipped, brand changed, campaigns swapped). Refetch the
+        // current filter view so the cards reconcile.
+        const sp = serializeLibraryQuery(parseLibraryQuery(searchParams));
+        sp.set("limit", "50");
+        fetch(`/api/library?${sp.toString()}`, { cache: "no-store" })
+          .then(async (res) => {
+            if (!res.ok) throw new Error(`status ${res.status}`);
+            return (await res.json()) as {
+              items: LibraryAsset[];
+              nextCursor: string | null;
+              total: number;
+            };
+          })
+          .then((data) => {
+            setItems(data.items);
+            setNextCursor(data.nextCursor);
+            setResultsCount(data.total);
+          })
+          .catch(() => {
+            /* non-fatal — selection already cleared, user can refresh */
+          });
+      }
+      clear();
+    },
+    [searchParams, setResultsCount, clear]
+  );
+
+  // Slim projection for the action bar — it only needs id/status/brand/owner
+  // to compute eligibility.
+  const selectedBulkAssets = useMemo<BulkBarAsset[]>(
+    () =>
+      items
+        .filter((it) => selectedIds.has(it.id))
+        .map((it) => ({
+          id: it.id,
+          brandId: it.brandId,
+          status: it.status,
+          userId: it.userId,
+        })),
+    [items, selectedIds]
+  );
+
+  const bulkBrandOptions = useMemo(
+    () =>
+      brands
+        .filter((b) => !b.isPersonal)
+        .map((b) => ({
+          id: b.id,
+          name: b.name,
+          color: b.color,
+          isPersonal: b.isPersonal,
+        })),
+    [brands]
+  );
 
   const handleBrandPinChange = useCallback(
     (brandId: string, assetId: string, pinned: boolean) => {
@@ -510,6 +628,7 @@ function LibraryGridContainer({
   return (
     <div className="space-y-4 pt-2">
       <div
+        ref={gridRef}
         // Subtle dim while a transition or filter fetch is pending — keeps
         // the user oriented without ripping the grid out from under them.
         className={cn(
@@ -517,6 +636,10 @@ function LibraryGridContainer({
           (isPending || loadingPage) && items.length > 0 && "opacity-60"
         )}
         aria-busy={isPending || loadingPage || undefined}
+        // Make the container focusable so Cmd/Ctrl+A is scoped — the keydown
+        // handler in `useBulkSelection` checks that the active element lives
+        // inside this node.
+        tabIndex={-1}
       >
         {blankEmpty && <LibraryBlankEmptyState />}
         {filteredEmpty && (
@@ -525,7 +648,15 @@ function LibraryGridContainer({
             onClearAll={clearAll}
           />
         )}
-        {!isEmpty && <LibraryGrid items={items} onSelect={setSelectedId} />}
+        {!isEmpty && (
+          <LibraryGrid
+            items={items}
+            onSelect={setSelectedId}
+            isSelected={isSelected}
+            onToggle={toggle}
+            selectionCount={bulkCount}
+          />
+        )}
 
         {/* Sentinel + spinner. Sentinel is always rendered when more pages exist
             so the observer keeps a target after each successful page. */}
@@ -553,6 +684,15 @@ function LibraryGridContainer({
         viewer={viewer}
         initialMessageId={urlMessageId}
       />
+
+      <BulkActionBar
+        assets={selectedBulkAssets}
+        viewer={bulkViewer}
+        brandOptions={bulkBrandOptions}
+        campaignOptions={facetCampaigns}
+        onClear={clear}
+        onApplied={handleBulkApplied}
+      />
     </div>
   );
 }
@@ -564,9 +704,15 @@ function LibraryGridContainer({
 function LibraryGrid({
   items,
   onSelect,
+  isSelected,
+  onToggle,
+  selectionCount,
 }: {
   items: LibraryAsset[];
   onSelect: (id: string) => void;
+  isSelected: (id: string) => boolean;
+  onToggle: (id: string, event?: { shiftKey?: boolean }) => void;
+  selectionCount: number;
 }) {
   return (
     <div
@@ -578,6 +724,9 @@ function LibraryGrid({
           key={item.id}
           asset={item}
           onClick={() => onSelect(item.id)}
+          selected={isSelected(item.id)}
+          onToggle={(event) => onToggle(item.id, event)}
+          selectionActive={selectionCount > 0}
         />
       ))}
     </div>
@@ -591,23 +740,58 @@ function LibraryGrid({
 function LibraryCard({
   asset,
   onClick,
+  selected,
+  onToggle,
+  selectionActive,
 }: {
   asset: LibraryAsset;
   onClick: () => void;
+  selected: boolean;
+  onToggle: (event: { shiftKey?: boolean }) => void;
+  selectionActive: boolean;
 }) {
+  // Card root is a div with role="button" — the card hosts a child checkbox
+  // that itself is a <button>, and nesting buttons is invalid HTML. Enter and
+  // Space are wired manually to preserve activation semantics. When the user
+  // holds shift while clicking the card itself we treat it as a range-select
+  // toggle (matching the checkbox's behavior) rather than opening the panel,
+  // so users can build up a multi-selection without aiming for the checkbox.
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <div
+      role="button"
+      tabIndex={0}
       data-slot="library-card"
+      data-selected={selected || undefined}
+      onClick={(e) => {
+        if (e.shiftKey || selectionActive) {
+          e.preventDefault();
+          onToggle({ shiftKey: e.shiftKey });
+          return;
+        }
+        onClick();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          if (e.shiftKey) {
+            onToggle({ shiftKey: true });
+          } else if (selectionActive) {
+            onToggle({});
+          } else {
+            onClick();
+          }
+        }
+      }}
       className={cn(
         "group/card relative cursor-pointer overflow-hidden rounded-xl bg-muted text-left",
         "ring-1 ring-foreground/10",
         "hover:-translate-y-0.5 hover:shadow-lg hover:ring-primary/40",
         "active:translate-y-px",
-        "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/60"
+        "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/60",
+        selected && "ring-2 ring-primary/70"
       )}
       aria-label={asset.fileName ?? `Asset ${asset.id.slice(0, 8)}`}
+      aria-pressed={selected}
     >
       <div className="relative aspect-square">
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -619,7 +803,13 @@ function LibraryCard({
           decoding="async"
         />
 
-        <div className="absolute left-2 top-2 flex items-center gap-1">
+        <BulkSelectCheckbox
+          checked={selected}
+          onToggle={onToggle}
+          alwaysVisible={selectionActive}
+        />
+
+        <div className="absolute left-9 top-2 flex items-center gap-1">
           <SourceBadge source={asset.source} />
           <StatusBadge status={asset.status} />
         </div>
@@ -667,7 +857,7 @@ function LibraryCard({
           </div>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/app/(dashboard)/review/review-client.tsx
+++ b/src/app/(dashboard)/review/review-client.tsx
@@ -398,9 +398,28 @@ export function ReviewClient({ viewer }: ReviewClientProps) {
         <ReviewModal
           open={modalOpen && queue.queue.length > 0}
           queue={queue.queue}
+          brandId={queue.brand.id}
           index={modalIndex}
           onIndexChange={setModalIndex}
           onAction={handleAction}
+          onCampaignsChange={(itemId, nextCampaigns) => {
+            setQueue((prev) => {
+              if (!prev) return prev;
+              return {
+                ...prev,
+                queue: prev.queue.map((q) =>
+                  q.id === itemId ? { ...q, campaigns: nextCampaigns } : q
+                ),
+              };
+            });
+            setDisplayQueue((prev) =>
+              prev
+                ? prev.map((q) =>
+                    q.id === itemId ? { ...q, campaigns: nextCampaigns } : q
+                  )
+                : prev
+            );
+          }}
           onClose={closeModal}
           displayQueue={displayQueue ?? undefined}
           sessionDecisions={sessionDecisions}

--- a/src/app/api/assets/[id]/campaigns/route.ts
+++ b/src/app/api/assets/[id]/campaigns/route.ts
@@ -1,18 +1,25 @@
 /**
  * PATCH /api/assets/[id]/campaigns — set the asset's campaign list (M2M
  * replace). Caller must be Creator+ on the asset's brand.
+ *
+ * Mutation logic lives in `@/lib/assets/mutations`; this route is the HTTP
+ * adapter. The bulk endpoint reuses the same helper with set/add/remove
+ * modes.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { assetCampaigns, assets, campaigns } from "@/lib/db/schema";
+import { assets } from "@/lib/db/schema";
 import {
-  canCreateAsset,
+  AssetMutationError,
+  setAssetCampaigns,
+} from "@/lib/assets/mutations";
+import {
   loadBrandContext,
   loadRoleContext,
 } from "@/lib/workspace/permissions";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 const bodySchema = z.object({
@@ -40,7 +47,16 @@ export async function PATCH(
   const desired = parsed.data.campaignIds;
 
   const [asset] = await db
-    .select({ id: assets.id, brandId: assets.brandId })
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
+    })
     .from(assets)
     .where(eq(assets.id, assetId))
     .limit(1);
@@ -54,33 +70,23 @@ export async function PATCH(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
   const ctx = await loadRoleContext(session.user.id, brandCtx.workspaceId);
-  if (!canCreateAsset(ctx, brandCtx)) {
-    return NextResponse.json({ error: "forbidden" }, { status: 403 });
-  }
 
-  // All campaign ids must belong to the asset's brand. Catches typos and
-  // cross-brand leakage.
-  if (desired.length > 0) {
-    const valid = await db
-      .select({ id: campaigns.id })
-      .from(campaigns)
-      .where(
-        and(eq(campaigns.brandId, asset.brandId), inArray(campaigns.id, desired))
-      );
-    if (valid.length !== desired.length) {
-      return NextResponse.json(
-        { error: "campaigns_not_in_brand" },
-        { status: 400 }
-      );
+  try {
+    const result = await setAssetCampaigns({
+      asset,
+      brandCtx,
+      ctx,
+      campaignIds: desired,
+      mode: "set",
+    });
+    return NextResponse.json({
+      success: true,
+      campaignIds: result.campaignIds,
+    });
+  } catch (err) {
+    if (err instanceof AssetMutationError) {
+      return NextResponse.json({ error: err.code }, { status: err.status });
     }
+    throw err;
   }
-
-  await db.delete(assetCampaigns).where(eq(assetCampaigns.assetId, assetId));
-  if (desired.length > 0) {
-    await db
-      .insert(assetCampaigns)
-      .values(desired.map((cid) => ({ assetId, campaignId: cid })));
-  }
-
-  return NextResponse.json({ success: true, campaignIds: desired });
 }

--- a/src/app/api/assets/[id]/reassign-brand/route.ts
+++ b/src/app/api/assets/[id]/reassign-brand/route.ts
@@ -13,20 +13,23 @@
  * Hard block: approved assets cannot be moved (FR-011 immutability) — caller
  * must fork first. On success, status resets to `draft` so the destination
  * brand's reviewers can vet the asset under their own standards.
+ *
+ * Mutation logic lives in `@/lib/assets/mutations`; this route is the HTTP
+ * adapter for the single-asset case.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { assets, brands } from "@/lib/db/schema";
+import { assets } from "@/lib/db/schema";
 import {
-  canCreateAsset,
-  isBrandManager,
-  isWorkspaceAdmin,
+  AssetMutationError,
+  reassignAssetBrand,
+} from "@/lib/assets/mutations";
+import {
   loadBrandContext,
   loadRoleContext,
 } from "@/lib/workspace/permissions";
-import { logReviewEvent } from "@/lib/transitions";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -55,108 +58,69 @@ export async function POST(
   }
   const targetBrandId = parsed.data.brandId;
 
-  // Load asset + source brand in one query.
-  const [row] = await db
+  const [asset] = await db
     .select({
-      assetId: assets.id,
-      assetUserId: assets.userId,
-      assetStatus: assets.status,
-      sourceBrandId: assets.brandId,
-      sourceWorkspaceId: brands.workspaceId,
-      sourceIsPersonal: brands.isPersonal,
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
     })
     .from(assets)
-    .innerJoin(brands, eq(brands.id, assets.brandId))
     .where(eq(assets.id, assetId))
     .limit(1);
 
-  if (!row) {
+  if (!asset) {
     return NextResponse.json({ error: "asset_not_found" }, { status: 404 });
   }
-  if (row.assetStatus === "approved") {
-    return NextResponse.json(
-      { error: "approved_immutable_fork_required" },
-      { status: 409 }
-    );
-  }
-  if (!row.sourceWorkspaceId || !row.sourceBrandId) {
+  if (!asset.brandId) {
     return NextResponse.json(
       { error: "source_workspace_missing" },
       { status: 500 }
     );
   }
-  if (row.sourceBrandId === targetBrandId) {
+
+  const sourceBrandCtx = await loadBrandContext(asset.brandId);
+  if (!sourceBrandCtx) {
     return NextResponse.json(
-      { error: "target_same_as_source" },
-      { status: 400 }
+      { error: "source_workspace_missing" },
+      { status: 500 }
     );
   }
 
-  // Source permission gate. We need source-side role context; the destination
-  // gate uses a separate context only if the destination is in another
-  // workspace (which we then reject anyway), so source ctx is enough here.
-  const sourceCtx = await loadRoleContext(userId, row.sourceWorkspaceId);
-  const isCreatorOfAsset = row.assetUserId === userId;
-  const sourceAllowed =
-    isCreatorOfAsset ||
-    isBrandManager(sourceCtx, row.sourceBrandId) ||
-    isWorkspaceAdmin(sourceCtx);
-  if (!sourceAllowed) {
-    return NextResponse.json({ error: "forbidden" }, { status: 403 });
-  }
-
-  // Load destination brand + check it's in the same workspace + non-Personal.
-  const destCtx = await loadBrandContext(targetBrandId);
-  if (!destCtx) {
+  const destBrandCtx = await loadBrandContext(targetBrandId);
+  if (!destBrandCtx) {
     return NextResponse.json(
       { error: "target_brand_not_found" },
       { status: 404 }
     );
   }
-  if (destCtx.workspaceId !== row.sourceWorkspaceId) {
-    return NextResponse.json(
-      { error: "cross_workspace_move_forbidden" },
-      { status: 403 }
-    );
+
+  const ctx = await loadRoleContext(userId, sourceBrandCtx.workspaceId);
+
+  try {
+    const result = await reassignAssetBrand({
+      asset,
+      targetBrandId,
+      ctx,
+      sourceBrandCtx,
+      destBrandCtx,
+      actorId: userId,
+    });
+    return NextResponse.json({
+      asset: {
+        id: result.assetId,
+        brandId: result.brandId,
+        status: result.status,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AssetMutationError) {
+      return NextResponse.json({ error: err.code }, { status: err.status });
+    }
+    throw err;
   }
-  if (destCtx.isPersonal) {
-    return NextResponse.json(
-      { error: "target_must_be_real_brand" },
-      { status: 400 }
-    );
-  }
-
-  // Destination permission gate — must be creator+ on destination.
-  if (!canCreateAsset(sourceCtx, destCtx)) {
-    return NextResponse.json({ error: "forbidden" }, { status: 403 });
-  }
-
-  // Two-step write — Neon HTTP driver lacks db.transaction. The asset update is
-  // the user-facing effect; on audit-log failure we accept the audit gap rather
-  // than rolling back the move.
-  await db
-    .update(assets)
-    .set({ brandId: targetBrandId, status: "draft", updatedAt: new Date() })
-    .where(eq(assets.id, assetId));
-
-  await logReviewEvent({
-    assetId,
-    actorId: userId,
-    action: "moved_brand",
-    fromStatus: row.assetStatus as
-      | "draft"
-      | "in_review"
-      | "approved"
-      | "rejected"
-      | "archived",
-    toStatus: "draft",
-  });
-
-  return NextResponse.json({
-    asset: {
-      id: assetId,
-      brandId: targetBrandId,
-      status: "draft" as const,
-    },
-  });
 }

--- a/src/app/api/assets/[id]/route.ts
+++ b/src/app/api/assets/[id]/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { assets, assetBrands, assetTags, brands, users } from "@/lib/db/schema";
-import { getAssetUrl, deleteFile, refreshImageInputUrls } from "@/lib/storage";
-import { canRead, loadRoleContext } from "@/lib/workspace/permissions";
+import { getAssetUrl, refreshImageInputUrls } from "@/lib/storage";
+import {
+  canRead,
+  loadBrandContext,
+  loadRoleContext,
+} from "@/lib/workspace/permissions";
+import { AssetMutationError, deleteAsset } from "@/lib/assets/mutations";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -253,13 +258,16 @@ export async function DELETE(
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-
+  const userId = session.user.id;
   const { id } = await params;
 
   const [asset] = await db
     .select({
       id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
       status: assets.status,
+      prompt: assets.prompt,
       r2Key: assets.r2Key,
       thumbnailR2Key: assets.thumbnailR2Key,
       webpR2Key: assets.webpR2Key,
@@ -272,27 +280,29 @@ export async function DELETE(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  // FR-011: approved assets are immutable; archive instead of deleting.
-  if (asset.status === "approved") {
-    return immutableResponse(asset.id);
-  }
+  // Per-asset auth via the shared helper. The helper preserves the FR-011
+  // approved-immutability guard (returns 409 with the legacy code so the
+  // existing client-side fork-prompt continues to work) and adds the
+  // creator/brand_manager/workspace-admin gate.
+  const brandCtx = asset.brandId ? await loadBrandContext(asset.brandId) : null;
+  const ctx = await loadRoleContext(
+    userId,
+    brandCtx?.workspaceId ?? ""
+  );
 
-  // Delete from storage
   try {
-    await deleteFile(asset.r2Key);
-    if (asset.thumbnailR2Key) {
-      await deleteFile(asset.thumbnailR2Key);
+    await deleteAsset({ asset, ctx, brandCtx, actorId: userId });
+  } catch (err) {
+    if (err instanceof AssetMutationError) {
+      // Preserve the legacy 409 shape with `forkUrl` for approved-immutable
+      // so the existing client behavior is unchanged.
+      if (err.code === "asset_immutable") {
+        return immutableResponse(asset.id);
+      }
+      return NextResponse.json({ error: err.code }, { status: err.status });
     }
-    if (asset.webpR2Key) {
-      await deleteFile(asset.webpR2Key);
-    }
-  } catch (error) {
-    // Log but don't fail - asset will be orphaned in storage
-    console.error("Failed to delete from storage:", error);
+    throw err;
   }
-
-  // Delete from DB (cascade will handle asset_brands and asset_tags)
-  await db.delete(assets).where(eq(assets.id, id));
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/assets/[id]/transition/route.ts
+++ b/src/app/api/assets/[id]/transition/route.ts
@@ -11,26 +11,21 @@
  *   - archive:       canRejectOrArchive
  *   - unarchive:     canRejectOrArchive (admin restoration path)
  *
- * The state transition + audit row are written atomically inside transitions.ts.
+ * Mutation logic lives in `@/lib/assets/mutations`; this route is the HTTP
+ * adapter for the single-asset case. The bulk endpoint reuses the same
+ * helper.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { assets, brands } from "@/lib/db/schema";
+import { assets } from "@/lib/db/schema";
 import {
-  createNotification,
-  createNotifications,
-  loadSubmitRecipients,
-  type NotificationInput,
-} from "@/lib/notifications";
-import {
-  checkTransitionPermission,
-  TransitionError,
-  transitionAsset,
-  type TransitionAction,
-} from "@/lib/transitions";
+  AssetMutationError,
+  transitionAssetMutation,
+} from "@/lib/assets/mutations";
+import { type TransitionAction } from "@/lib/transitions";
 import {
   loadBrandContext,
   loadRoleContext,
@@ -69,6 +64,9 @@ export async function POST(
       brandId: assets.brandId,
       status: assets.status,
       prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
     })
     .from(assets)
     .where(eq(assets.id, id))
@@ -77,7 +75,6 @@ export async function POST(
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
   if (!asset.brandId) {
-    // Agency-DAM data invariant: every asset has a brandId post-Phase-2 backfill.
     return NextResponse.json({ error: "asset_missing_brand" }, { status: 409 });
   }
 
@@ -91,46 +88,14 @@ export async function POST(
     return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 
-  // Synthesize creator role on Personal brand if the membership row is missing —
-  // mirrors the same carve-out in /api/generate so the user can always
-  // archive/unarchive their own scratch space.
-  if (
-    brandCtx.isPersonal &&
-    brandCtx.ownerId === userId &&
-    !ctx.brandMemberships.has(brandCtx.id)
-  ) {
-    ctx.brandMemberships.set(brandCtx.id, "creator");
-  }
-
-  const allowed = checkTransitionPermission(
-    action as TransitionAction,
-    ctx,
-    asset,
-    brandCtx
-  );
-  if (!allowed.ok) {
-    return NextResponse.json({ error: allowed.code }, { status: allowed.status });
-  }
-
   try {
-    const result = await transitionAsset({
-      assetId: asset.id,
-      actorId: userId,
+    const result = await transitionAssetMutation({
+      asset,
       action: action as TransitionAction,
-      note,
-    });
-
-    // Best-effort fan-out — a notification write failure must not roll back
-    // the transition (the audit log is the system of record). We swallow and
-    // log; the bell will just miss this event.
-    void fanOutNotifications({
-      action: action as TransitionAction,
+      ctx,
+      brandCtx,
       actorId: userId,
-      asset: { id: asset.id, userId: asset.userId, prompt: asset.prompt },
-      brand: brandCtx,
       note,
-    }).catch((err) => {
-      console.error("notifications.fanOut failed", err);
     });
 
     return NextResponse.json({
@@ -140,83 +105,9 @@ export async function POST(
       toStatus: result.toStatus,
     });
   } catch (err) {
-    if (err instanceof TransitionError) {
+    if (err instanceof AssetMutationError) {
       return NextResponse.json({ error: err.code }, { status: err.status });
     }
     throw err;
   }
-}
-
-interface FanOutInput {
-  action: TransitionAction;
-  actorId: string;
-  asset: { id: string; userId: string; prompt: string };
-  brand: { id: string; workspaceId: string };
-  note?: string;
-}
-
-async function fanOutNotifications(input: FanOutInput): Promise<void> {
-  const { action, actorId, asset, brand, note } = input;
-  if (action !== "submit" && action !== "approve" && action !== "reject") {
-    return;
-  }
-
-  // Brand slug for the review queue href. Fall back to id if unset.
-  const [brandRow] = await db
-    .select({ slug: brands.slug, name: brands.name })
-    .from(brands)
-    .where(eq(brands.id, brand.id))
-    .limit(1);
-  const brandSlug = brandRow?.slug ?? brand.id;
-  const brandName = brandRow?.name ?? null;
-  const reviewHref = `/brands/${brandSlug}/review`;
-  const assetTitle = excerpt(asset.prompt);
-
-  if (action === "submit") {
-    const recipients = await loadSubmitRecipients({
-      actorId,
-      brandId: brand.id,
-      workspaceId: brand.workspaceId,
-    });
-    const inputs: NotificationInput[] = recipients.map((userId) => ({
-      userId,
-      workspaceId: brand.workspaceId,
-      actorId,
-      type: "asset_submitted",
-      payload: {
-        assetId: asset.id,
-        brandId: brand.id,
-        brandName,
-        assetTitle,
-      },
-      href: reviewHref,
-    }));
-    await createNotifications(inputs);
-    return;
-  }
-
-  // approve / reject — notify the uploader if they aren't the actor.
-  if (asset.userId === actorId) return;
-
-  // No dedicated asset-detail page exists yet; link to the brand review queue.
-  await createNotification({
-    userId: asset.userId,
-    workspaceId: brand.workspaceId,
-    actorId,
-    type: action === "approve" ? "asset_approved" : "asset_rejected",
-    payload: {
-      assetId: asset.id,
-      brandId: brand.id,
-      brandName,
-      assetTitle,
-      ...(note ? { note } : {}),
-    },
-    href: reviewHref,
-  });
-}
-
-function excerpt(text: string, max = 80): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= max) return trimmed;
-  return trimmed.slice(0, max - 1) + "…";
 }

--- a/src/app/api/assets/bulk/campaigns/route.ts
+++ b/src/app/api/assets/bulk/campaigns/route.ts
@@ -1,0 +1,160 @@
+/**
+ * PATCH /api/assets/bulk/campaigns — set/add/remove campaigns on many assets.
+ *
+ * Body: `{ ids, campaignIds, mode: "set" | "add" | "remove" }` (max 200 ids,
+ * max 32 campaign ids). Cross-brand selections are surfaced as `failed[]`
+ * entries since campaigns are brand-scoped — the UI prevents this case via
+ * the picker, but the server is the source of truth.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { assets } from "@/lib/db/schema";
+import {
+  AssetMutationError,
+  setAssetCampaigns,
+  type CampaignMode,
+} from "@/lib/assets/mutations";
+import {
+  loadBrandContext,
+  loadRoleContext,
+  type BrandContext,
+  type RoleContext,
+} from "@/lib/workspace/permissions";
+
+const bodySchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(200),
+  campaignIds: z.array(z.string().uuid()).max(32),
+  mode: z.enum(["set", "add", "remove"]),
+});
+
+interface BulkResult {
+  requested: number;
+  succeeded: string[];
+  failed: { id: string; code: string; message: string }[];
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const { ids, campaignIds, mode } = parsed.data;
+  const requestedIds = Array.from(new Set(ids));
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
+    })
+    .from(assets)
+    .where(inArray(assets.id, requestedIds));
+
+  const result: BulkResult = {
+    requested: requestedIds.length,
+    succeeded: [],
+    failed: [],
+  };
+  const seen = new Set(rows.map((r) => r.id));
+  for (const id of requestedIds) {
+    if (!seen.has(id)) {
+      result.failed.push({
+        id,
+        code: "not_found",
+        message: "Asset not found",
+      });
+    }
+  }
+
+  const brandIds = Array.from(
+    new Set(rows.map((r) => r.brandId).filter((b): b is string => Boolean(b)))
+  );
+  const brandCache = new Map<string, BrandContext>();
+  await Promise.all(
+    brandIds.map(async (id) => {
+      const ctx = await loadBrandContext(id);
+      if (ctx) brandCache.set(id, ctx);
+    })
+  );
+
+  const ctxCache = new Map<string, RoleContext>();
+  const workspaceIds = Array.from(
+    new Set(Array.from(brandCache.values()).map((b) => b.workspaceId))
+  );
+  await Promise.all(
+    workspaceIds.map(async (wsId) => {
+      ctxCache.set(wsId, await loadRoleContext(userId, wsId));
+    })
+  );
+
+  for (const row of rows) {
+    if (!row.brandId) {
+      result.failed.push({
+        id: row.id,
+        code: "asset_missing_brand",
+        message: "Asset has no brand context",
+      });
+      continue;
+    }
+    const brandCtx = brandCache.get(row.brandId);
+    if (!brandCtx) {
+      result.failed.push({
+        id: row.id,
+        code: "brand_not_found",
+        message: "Brand not found",
+      });
+      continue;
+    }
+    const ctx = ctxCache.get(brandCtx.workspaceId);
+    if (!ctx) {
+      result.failed.push({
+        id: row.id,
+        code: "forbidden",
+        message: "Forbidden",
+      });
+      continue;
+    }
+
+    try {
+      await setAssetCampaigns({
+        asset: row,
+        brandCtx,
+        ctx,
+        campaignIds,
+        mode: mode as CampaignMode,
+      });
+      result.succeeded.push(row.id);
+    } catch (err) {
+      if (err instanceof AssetMutationError) {
+        result.failed.push({ id: row.id, code: err.code, message: err.message });
+      } else {
+        console.error("bulk campaigns failed", row.id, err);
+        result.failed.push({
+          id: row.id,
+          code: "internal_error",
+          message: "Internal error",
+        });
+      }
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/assets/bulk/reassign-brand/route.ts
+++ b/src/app/api/assets/bulk/reassign-brand/route.ts
@@ -1,0 +1,176 @@
+/**
+ * POST /api/assets/bulk/reassign-brand — move many assets to a target brand.
+ *
+ * Body: `{ ids: string[] (max 200), targetBrandId }`. Returns 200 with
+ * `{ requested, succeeded, failed }`. Approved assets are intentionally
+ * surfaced in `failed[]` (not rolled back) so the UI can show the user
+ * which ones need a fork.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { assets } from "@/lib/db/schema";
+import {
+  AssetMutationError,
+  reassignAssetBrand,
+} from "@/lib/assets/mutations";
+import {
+  loadBrandContext,
+  loadRoleContext,
+  type BrandContext,
+  type RoleContext,
+} from "@/lib/workspace/permissions";
+
+const bodySchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(200),
+  targetBrandId: z.string().uuid(),
+});
+
+interface BulkResult {
+  requested: number;
+  succeeded: string[];
+  failed: { id: string; code: string; message: string }[];
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const { ids, targetBrandId } = parsed.data;
+  const requestedIds = Array.from(new Set(ids));
+
+  const destBrandCtx = await loadBrandContext(targetBrandId);
+  if (!destBrandCtx) {
+    return NextResponse.json(
+      { error: "target_brand_not_found" },
+      { status: 404 }
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
+    })
+    .from(assets)
+    .where(inArray(assets.id, requestedIds));
+
+  const result: BulkResult = {
+    requested: requestedIds.length,
+    succeeded: [],
+    failed: [],
+  };
+  const seen = new Set(rows.map((r) => r.id));
+  for (const id of requestedIds) {
+    if (!seen.has(id)) {
+      result.failed.push({
+        id,
+        code: "not_found",
+        message: "Asset not found",
+      });
+    }
+  }
+
+  const brandIds = Array.from(
+    new Set(
+      rows
+        .map((r) => r.brandId)
+        .filter((b): b is string => Boolean(b))
+    )
+  );
+  const brandCache = new Map<string, BrandContext>();
+  // Always include the destination brand context — its workspace anchors the
+  // RoleContext load (cross-workspace moves are forbidden, so source ctxs
+  // share the same workspace).
+  brandCache.set(destBrandCtx.id, destBrandCtx);
+  await Promise.all(
+    brandIds.map(async (id) => {
+      if (brandCache.has(id)) return;
+      const ctx = await loadBrandContext(id);
+      if (ctx) brandCache.set(id, ctx);
+    })
+  );
+
+  const ctxCache = new Map<string, RoleContext>();
+  const workspaceIds = Array.from(
+    new Set(Array.from(brandCache.values()).map((b) => b.workspaceId))
+  );
+  await Promise.all(
+    workspaceIds.map(async (wsId) => {
+      ctxCache.set(wsId, await loadRoleContext(userId, wsId));
+    })
+  );
+
+  for (const row of rows) {
+    if (!row.brandId) {
+      result.failed.push({
+        id: row.id,
+        code: "source_workspace_missing",
+        message: "Asset has no source brand",
+      });
+      continue;
+    }
+    const sourceBrandCtx = brandCache.get(row.brandId);
+    if (!sourceBrandCtx) {
+      result.failed.push({
+        id: row.id,
+        code: "brand_not_found",
+        message: "Source brand not found",
+      });
+      continue;
+    }
+    const ctx = ctxCache.get(sourceBrandCtx.workspaceId);
+    if (!ctx) {
+      result.failed.push({
+        id: row.id,
+        code: "forbidden",
+        message: "Forbidden",
+      });
+      continue;
+    }
+
+    try {
+      await reassignAssetBrand({
+        asset: row,
+        targetBrandId,
+        ctx,
+        sourceBrandCtx,
+        destBrandCtx,
+        actorId: userId,
+      });
+      result.succeeded.push(row.id);
+    } catch (err) {
+      if (err instanceof AssetMutationError) {
+        result.failed.push({ id: row.id, code: err.code, message: err.message });
+      } else {
+        console.error("bulk reassign-brand failed", row.id, err);
+        result.failed.push({
+          id: row.id,
+          code: "internal_error",
+          message: "Internal error",
+        });
+      }
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/assets/bulk/route.ts
+++ b/src/app/api/assets/bulk/route.ts
@@ -1,0 +1,138 @@
+/**
+ * DELETE /api/assets/bulk — delete many assets.
+ *
+ * Body: `{ ids: string[] (max 200) }`. Returns 200 with
+ * `{ requested, succeeded, failed }`. Approved assets land in `failed[]`
+ * with `code: "asset_immutable"` so the UI can surface the fork prompt.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { assets } from "@/lib/db/schema";
+import { AssetMutationError, deleteAsset } from "@/lib/assets/mutations";
+import {
+  loadBrandContext,
+  loadRoleContext,
+  type BrandContext,
+  type RoleContext,
+} from "@/lib/workspace/permissions";
+
+const bodySchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(200),
+});
+
+interface BulkResult {
+  requested: number;
+  succeeded: string[];
+  failed: { id: string; code: string; message: string }[];
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const requestedIds = Array.from(new Set(parsed.data.ids));
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
+    })
+    .from(assets)
+    .where(inArray(assets.id, requestedIds));
+
+  const result: BulkResult = {
+    requested: requestedIds.length,
+    succeeded: [],
+    failed: [],
+  };
+  const seen = new Set(rows.map((r) => r.id));
+  for (const id of requestedIds) {
+    if (!seen.has(id)) {
+      result.failed.push({
+        id,
+        code: "not_found",
+        message: "Asset not found",
+      });
+    }
+  }
+
+  const brandIds = Array.from(
+    new Set(rows.map((r) => r.brandId).filter((b): b is string => Boolean(b)))
+  );
+  const brandCache = new Map<string, BrandContext>();
+  await Promise.all(
+    brandIds.map(async (id) => {
+      const ctx = await loadBrandContext(id);
+      if (ctx) brandCache.set(id, ctx);
+    })
+  );
+
+  const ctxCache = new Map<string, RoleContext>();
+  const workspaceIds = Array.from(
+    new Set(Array.from(brandCache.values()).map((b) => b.workspaceId))
+  );
+  // Orphan assets (no brand) still need a RoleContext for the workspace-admin
+  // override path, but with no workspace anchor the helper returns the
+  // creator-only branch — match that here by skipping the load.
+  await Promise.all(
+    workspaceIds.map(async (wsId) => {
+      ctxCache.set(wsId, await loadRoleContext(userId, wsId));
+    })
+  );
+
+  for (const row of rows) {
+    const brandCtx = row.brandId ? brandCache.get(row.brandId) ?? null : null;
+    const ctx = brandCtx
+      ? ctxCache.get(brandCtx.workspaceId)
+      : ({
+          userId,
+          workspace: null,
+          brandMemberships: new Map(),
+        } satisfies RoleContext);
+    if (!ctx) {
+      result.failed.push({
+        id: row.id,
+        code: "forbidden",
+        message: "Forbidden",
+      });
+      continue;
+    }
+    try {
+      await deleteAsset({ asset: row, ctx, brandCtx, actorId: userId });
+      result.succeeded.push(row.id);
+    } catch (err) {
+      if (err instanceof AssetMutationError) {
+        result.failed.push({ id: row.id, code: err.code, message: err.message });
+      } else {
+        console.error("bulk delete failed", row.id, err);
+        result.failed.push({
+          id: row.id,
+          code: "internal_error",
+          message: "Internal error",
+        });
+      }
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/assets/bulk/transition/route.ts
+++ b/src/app/api/assets/bulk/transition/route.ts
@@ -1,0 +1,163 @@
+/**
+ * POST /api/assets/bulk/transition — apply a state transition to many assets.
+ *
+ * Body: `{ ids: string[] (max 200), action, note? }`.
+ *
+ * Always returns 200 with `{ requested, succeeded, failed }` — partial
+ * failures are surfaced in `failed[]` rather than rolled back. The UI shows
+ * a summary toast and reconciles its local state from `succeeded`.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { assets } from "@/lib/db/schema";
+import {
+  AssetMutationError,
+  transitionAssetMutation,
+} from "@/lib/assets/mutations";
+import { type TransitionAction } from "@/lib/transitions";
+import {
+  loadBrandContext,
+  loadRoleContext,
+  type BrandContext,
+  type RoleContext,
+} from "@/lib/workspace/permissions";
+
+const bodySchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(200),
+  action: z.enum(["submit", "approve", "reject", "archive", "unarchive"]),
+  note: z.string().max(2000).optional(),
+});
+
+interface BulkResult {
+  requested: number;
+  succeeded: string[];
+  failed: { id: string; code: string; message: string }[];
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const parsed = bodySchema.safeParse(await req.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid input", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const { ids, action, note } = parsed.data;
+  const requestedIds = Array.from(new Set(ids));
+
+  const rows = await db
+    .select({
+      id: assets.id,
+      userId: assets.userId,
+      brandId: assets.brandId,
+      status: assets.status,
+      prompt: assets.prompt,
+      r2Key: assets.r2Key,
+      thumbnailR2Key: assets.thumbnailR2Key,
+      webpR2Key: assets.webpR2Key,
+    })
+    .from(assets)
+    .where(inArray(assets.id, requestedIds));
+
+  const result: BulkResult = {
+    requested: requestedIds.length,
+    succeeded: [],
+    failed: [],
+  };
+  const seen = new Set(rows.map((r) => r.id));
+  for (const id of requestedIds) {
+    if (!seen.has(id)) {
+      result.failed.push({
+        id,
+        code: "not_found",
+        message: "Asset not found",
+      });
+    }
+  }
+
+  // Group by brand so each BrandContext / RoleContext is loaded exactly once.
+  const brandIds = Array.from(
+    new Set(rows.map((r) => r.brandId).filter((b): b is string => Boolean(b)))
+  );
+  const brandCache = new Map<string, BrandContext>();
+  await Promise.all(
+    brandIds.map(async (id) => {
+      const ctx = await loadBrandContext(id);
+      if (ctx) brandCache.set(id, ctx);
+    })
+  );
+
+  const ctxCache = new Map<string, RoleContext>();
+  const workspaceIds = Array.from(
+    new Set(Array.from(brandCache.values()).map((b) => b.workspaceId))
+  );
+  await Promise.all(
+    workspaceIds.map(async (wsId) => {
+      ctxCache.set(wsId, await loadRoleContext(userId, wsId));
+    })
+  );
+
+  for (const row of rows) {
+    if (!row.brandId) {
+      result.failed.push({
+        id: row.id,
+        code: "asset_missing_brand",
+        message: "Asset has no brand context",
+      });
+      continue;
+    }
+    const brandCtx = brandCache.get(row.brandId);
+    if (!brandCtx) {
+      result.failed.push({
+        id: row.id,
+        code: "brand_not_found",
+        message: "Brand not found",
+      });
+      continue;
+    }
+    const ctx = ctxCache.get(brandCtx.workspaceId);
+    if (!ctx || !ctx.workspace) {
+      result.failed.push({
+        id: row.id,
+        code: "forbidden",
+        message: "Forbidden",
+      });
+      continue;
+    }
+
+    try {
+      await transitionAssetMutation({
+        asset: row,
+        action: action as TransitionAction,
+        ctx,
+        brandCtx,
+        actorId: userId,
+        note,
+      });
+      result.succeeded.push(row.id);
+    } catch (err) {
+      if (err instanceof AssetMutationError) {
+        result.failed.push({ id: row.id, code: err.code, message: err.message });
+      } else {
+        console.error("bulk transition failed", row.id, err);
+        result.failed.push({
+          id: row.id,
+          code: "internal_error",
+          message: "Internal error",
+        });
+      }
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/components/asset/campaign-picker.tsx
+++ b/src/components/asset/campaign-picker.tsx
@@ -1,0 +1,501 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  Loader2,
+  Megaphone,
+  Plus,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+interface CampaignOption {
+  id: string;
+  name: string;
+}
+
+export interface CampaignTag {
+  id: string;
+  name: string;
+}
+
+interface CampaignPickerProps {
+  assetId: string;
+  brandId: string | null;
+  campaigns: CampaignTag[];
+  onChange?: (next: CampaignTag[]) => void;
+  hideWhenEmptyBrand?: boolean;
+}
+
+interface MeResponse {
+  userId: string | null;
+  role: "owner" | "admin" | "member" | null;
+  brandRoles: Record<string, "brand_manager" | "creator" | "viewer">;
+}
+
+let cachedMe: MeResponse | null = null;
+let inflightMe: Promise<MeResponse | null> | null = null;
+
+function fetchMe(): Promise<MeResponse | null> {
+  if (cachedMe) return Promise.resolve(cachedMe);
+  if (inflightMe) return inflightMe;
+  inflightMe = fetch("/api/me")
+    .then((r) => (r.ok ? r.json() : null))
+    .then((data: MeResponse | null) => {
+      if (data) cachedMe = data;
+      inflightMe = null;
+      return data;
+    })
+    .catch(() => {
+      inflightMe = null;
+      return null;
+    });
+  return inflightMe;
+}
+
+function isBrandCreatorClient(me: MeResponse | null, brandId: string): boolean {
+  if (!me) return false;
+  if (me.role === "owner" || me.role === "admin") return true;
+  const r = me.brandRoles[brandId];
+  return r === "brand_manager" || r === "creator";
+}
+
+export function CampaignPicker({
+  assetId,
+  brandId,
+  campaigns,
+  onChange,
+  hideWhenEmptyBrand = true,
+}: CampaignPickerProps) {
+  const [me, setMe] = useState<MeResponse | null>(cachedMe);
+  const [meLoaded, setMeLoaded] = useState<boolean>(cachedMe !== null);
+
+  useEffect(() => {
+    if (meLoaded) return;
+    let cancelled = false;
+    fetchMe().then((data) => {
+      if (cancelled) return;
+      setMe(data);
+      setMeLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [meLoaded]);
+
+  const [selected, setSelected] = useState<CampaignTag[]>(campaigns);
+  const [seenAssetId, setSeenAssetId] = useState(assetId);
+  if (seenAssetId !== assetId) {
+    setSeenAssetId(assetId);
+    setSelected(campaigns);
+  }
+
+  const [options, setOptions] = useState<CampaignOption[] | null>(null);
+  const [open, setOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !brandId) return;
+    let cancelled = false;
+    fetch(`/api/campaigns?brandId=${brandId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const rows = Array.isArray(data.campaigns) ? data.campaigns : [];
+        setOptions(
+          rows.map((c: { id: string; name: string }) => ({
+            id: c.id,
+            name: c.name,
+          }))
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOptions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, brandId]);
+
+  if (!meLoaded) return null;
+  if (!brandId) {
+    if (hideWhenEmptyBrand) return null;
+    return (
+      <div className="flex flex-col gap-2">
+        <Label>Campaigns</Label>
+        <p className="text-xs text-muted-foreground">
+          This asset isn&apos;t on a brand, so it can&apos;t be added to a
+          campaign.
+        </p>
+      </div>
+    );
+  }
+  if (!isBrandCreatorClient(me, brandId)) return null;
+
+  const persist = async (next: CampaignTag[], pending: string) => {
+    setPendingId(pending);
+    const ok = await patchAssetCampaigns(
+      assetId,
+      next.map((c) => c.id)
+    );
+    setPendingId(null);
+    return ok;
+  };
+
+  const handleToggle = async (option: CampaignOption) => {
+    const exists = selected.some((c) => c.id === option.id);
+    const next = exists
+      ? selected.filter((c) => c.id !== option.id)
+      : [...selected, { id: option.id, name: option.name }];
+    const ok = await persist(next, option.id);
+    if (!ok) {
+      toast.error("Couldn't update campaigns. Try again.");
+      return;
+    }
+    setSelected(next);
+    onChange?.(next);
+  };
+
+  const handleRemoveChip = async (campaignId: string) => {
+    const next = selected.filter((c) => c.id !== campaignId);
+    const ok = await persist(next, campaignId);
+    if (!ok) {
+      toast.error("Couldn't remove campaign. Try again.");
+      return;
+    }
+    setSelected(next);
+    onChange?.(next);
+  };
+
+  const handleCreated = async (campaign: CampaignOption) => {
+    setOptions((prev) => (prev ? [...prev, campaign] : [campaign]));
+    const next = [...selected, { id: campaign.id, name: campaign.name }];
+    const ok = await persist(next, campaign.id);
+    if (ok) {
+      setSelected(next);
+      onChange?.(next);
+    }
+  };
+
+  const trimmed = search.trim().toLowerCase();
+  const filtered = (options ?? []).filter((c) =>
+    trimmed.length === 0 ? true : c.name.toLowerCase().includes(trimmed)
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>Campaigns</Label>
+
+      {selected.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => handleRemoveChip(c.id)}
+              disabled={pendingId === c.id}
+              className={cn(
+                "group/chip inline-flex h-6 items-center gap-1 rounded-md bg-primary/10 px-2 text-xs font-medium text-primary ring-1 ring-primary/25 transition-colors",
+                "hover:bg-destructive/10 hover:text-destructive hover:ring-destructive/30",
+                "focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                pendingId === c.id && "opacity-60"
+              )}
+              aria-label={`Remove campaign ${c.name}`}
+            >
+              <Megaphone
+                className="size-3 text-current opacity-70"
+                aria-hidden
+              />
+              <span>{c.name}</span>
+              {pendingId === c.id ? (
+                <Loader2 className="size-3 animate-spin" aria-hidden />
+              ) : (
+                <X
+                  className="size-3 opacity-60 transition-opacity group-hover/chip:opacity-100"
+                  aria-hidden
+                />
+              )}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Group assets by campaign to keep launches organized.
+        </p>
+      )}
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="justify-between gap-2"
+              aria-label="Add to campaign"
+            >
+              <span className="text-muted-foreground">Add to campaign…</span>
+              <ChevronDown
+                className="size-3.5 text-muted-foreground"
+                aria-hidden
+              />
+            </Button>
+          }
+        />
+        <PopoverContent align="start" className="w-72 p-0">
+          <div className="border-b border-border p-1">
+            <Input
+              autoFocus
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search campaigns…"
+              className="h-8 border-none bg-transparent px-2 text-sm shadow-none focus-visible:border-none focus-visible:ring-0"
+            />
+          </div>
+          <div className="max-h-64 overflow-y-auto p-1">
+            {options === null ? (
+              <div className="flex items-center justify-center py-4 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              </div>
+            ) : filtered.length === 0 ? (
+              <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+                {trimmed ? "No matches." : "No campaigns yet on this brand."}
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-0.5">
+                {filtered.map((c) => {
+                  const checked = selected.some((x) => x.id === c.id);
+                  const busy = pendingId === c.id;
+                  return (
+                    <li key={c.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleToggle(c)}
+                        disabled={busy}
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                          "hover:bg-accent",
+                          checked && "bg-primary/10 text-primary",
+                          busy && "opacity-60"
+                        )}
+                      >
+                        <span
+                          aria-hidden
+                          className={cn(
+                            "flex size-4 items-center justify-center rounded-sm border",
+                            checked
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-foreground/25"
+                          )}
+                        >
+                          {checked && <Check className="size-3" aria-hidden />}
+                        </span>
+                        <Megaphone
+                          className="size-3.5 text-muted-foreground"
+                          aria-hidden
+                        />
+                        <span className="flex-1 truncate">{c.name}</span>
+                        {busy && (
+                          <Loader2
+                            className="size-3 animate-spin text-muted-foreground"
+                            aria-hidden
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+          <div className="border-t border-border p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setCreateOpen(true);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm",
+                "hover:bg-accent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Plus className="size-3.5" aria-hidden />
+              New campaign
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <CreateCampaignDialog
+        open={createOpen}
+        brandId={brandId}
+        onOpenChange={setCreateOpen}
+        onCreated={handleCreated}
+      />
+    </div>
+  );
+}
+
+async function patchAssetCampaigns(
+  id: string,
+  campaignIds: string[]
+): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/assets/${id}/campaigns`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ campaignIds }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function CreateCampaignDialog({
+  open,
+  brandId,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  brandId: string;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (campaign: { id: string; name: string }) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (!open) {
+      setName("");
+      setDescription("");
+    }
+  }
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setCreating(true);
+    try {
+      const res = await fetch("/api/campaigns", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          brandId,
+          name: trimmed,
+          description: description.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(
+          data.error === "campaign_name_collision"
+            ? "A campaign with that name already exists."
+            : data.error === "forbidden"
+              ? "You don't have permission to create campaigns on this brand."
+              : "Couldn't create campaign. Try again."
+        );
+        return;
+      }
+      const data = (await res.json()) as {
+        campaign: { id: string; name: string };
+      };
+      toast.success("Campaign created");
+      onCreated({ id: data.campaign.id, name: data.campaign.name });
+      onOpenChange(false);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onOpenChange(false);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New campaign</DialogTitle>
+          <DialogDescription>
+            Group assets under a launch, drop, or initiative.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-campaign-name">Name</Label>
+            <Input
+              id="new-campaign-name"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Spring sale 2026"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !creating && name.trim()) {
+                  e.preventDefault();
+                  handleCreate();
+                }
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="new-campaign-desc">Description (optional)</Label>
+            <Textarea
+              id="new-campaign-desc"
+              rows={2}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={creating}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={creating || !name.trim()}>
+            {creating ? (
+              <>
+                <Loader2 className="animate-spin" aria-hidden />
+                Creating…
+              </>
+            ) : (
+              "Create"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bulk/bulk-action-bar.tsx
+++ b/src/components/bulk/bulk-action-bar.tsx
@@ -1,0 +1,573 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  Archive,
+  ArrowRightLeft,
+  CheckCircle2,
+  FolderInput,
+  Send,
+  Trash2,
+  X,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  BulkBrandPicker,
+  type BulkBrandOption,
+} from "./bulk-brand-picker";
+import {
+  BulkCampaignPicker,
+  type BulkCampaignOption,
+} from "./bulk-campaign-picker";
+import type { CampaignMode } from "@/lib/assets/mutations";
+
+/**
+ * Asset shape the action bar reads to compute eligibility. Both the Library
+ * and Gallery clients pass a slim projection from their richer asset types.
+ */
+export interface BulkBarAsset {
+  id: string;
+  brandId: string | null;
+  status: "draft" | "in_review" | "approved" | "rejected" | "archived" | null;
+  userId: string;
+}
+
+export type BulkActionKind =
+  | "submit"
+  | "approve"
+  | "reject"
+  | "archive"
+  | "delete"
+  | "moveBrand"
+  | "campaigns";
+
+export interface BulkServerResult {
+  requested: number;
+  succeeded: string[];
+  failed: { id: string; code: string; message: string }[];
+}
+
+interface BulkActionBarProps {
+  /** All currently-selected assets (slim projection). */
+  assets: BulkBarAsset[];
+  /** Current viewer's permissions per brand (server is source of truth, this
+   *  just toggles the buttons). */
+  viewer: {
+    userId: string | null;
+    workspaceRole: "owner" | "admin" | "member" | null;
+    brandRoles: Record<string, "brand_manager" | "creator" | "viewer">;
+  };
+  /** Brands the user can move assets into. Filtered by the picker. */
+  brandOptions: BulkBrandOption[];
+  /** Campaigns the user can see across all brands. Picker filters per brand. */
+  campaignOptions: BulkCampaignOption[];
+  /** When set, hide "Move to brand" — the surrounding view is locked to one
+   *  brand (Brand Gallery). */
+  lockedBrandId?: string;
+  onClear: () => void;
+  /** Fired after the API responds. Pass the asset ids that succeeded so the
+   *  parent can patch its local state. */
+  onApplied: (kind: BulkActionKind, succeeded: string[]) => void;
+}
+
+interface ConfirmState {
+  kind: "reject" | "archive" | "delete";
+  count: number;
+}
+
+export function BulkActionBar({
+  assets,
+  viewer,
+  brandOptions,
+  campaignOptions,
+  lockedBrandId,
+  onClear,
+  onApplied,
+}: BulkActionBarProps) {
+  const [submitting, setSubmitting] = useState<BulkActionKind | null>(null);
+  const [brandPickerOpen, setBrandPickerOpen] = useState(false);
+  const [campaignPickerOpen, setCampaignPickerOpen] = useState(false);
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null);
+
+  const counts = useMemo(() => computeCounts(assets, viewer), [assets, viewer]);
+
+  if (assets.length === 0) return null;
+
+  const selectionBrandIds = Array.from(
+    new Set(assets.map((a) => a.brandId).filter((b): b is string => Boolean(b)))
+  );
+  const singleBrandId =
+    selectionBrandIds.length === 1 ? selectionBrandIds[0] : null;
+
+  const fire = async (kind: BulkActionKind, run: () => Promise<BulkServerResult>) => {
+    setSubmitting(kind);
+    try {
+      const result = await run();
+      onApplied(kind, result.succeeded);
+      summarizeToast(kind, result);
+    } catch {
+      toast.error("Couldn't complete that action. Try again.");
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  const handleTransition = (
+    action: "submit" | "approve" | "reject" | "archive"
+  ) =>
+    fire(action, () =>
+      callBulk("/api/assets/bulk/transition", "POST", {
+        ids: assets.map((a) => a.id),
+        action,
+      })
+    );
+
+  const handleDelete = () =>
+    fire("delete", () =>
+      callBulk("/api/assets/bulk", "DELETE", {
+        ids: assets.map((a) => a.id),
+      })
+    );
+
+  const handleReassign = (brandId: string) =>
+    fire("moveBrand", () =>
+      callBulk("/api/assets/bulk/reassign-brand", "POST", {
+        ids: assets.map((a) => a.id),
+        targetBrandId: brandId,
+      })
+    );
+
+  const handleCampaigns = (input: {
+    campaignIds: string[];
+    mode: CampaignMode;
+  }) =>
+    fire("campaigns", () =>
+      callBulk("/api/assets/bulk/campaigns", "PATCH", {
+        ids: assets.map((a) => a.id),
+        campaignIds: input.campaignIds,
+        mode: input.mode,
+      })
+    );
+
+  return (
+    <>
+      <div
+        role="toolbar"
+        aria-label="Bulk actions"
+        data-slot="bulk-action-bar"
+        className={cn(
+          "fixed bottom-4 left-1/2 z-40 -translate-x-1/2",
+          "flex max-w-[min(100vw-2rem,720px)] items-center gap-1.5 rounded-2xl bg-card px-2 py-2 ring-1 ring-foreground/10 shadow-lg",
+          "animate-in fade-in slide-in-from-bottom-2 duration-150"
+        )}
+      >
+        <div className="flex items-center gap-2 px-2">
+          <span
+            aria-live="polite"
+            className="font-mono text-xs tabular-nums text-muted-foreground"
+          >
+            {assets.length} selected
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Clear selection"
+            onClick={onClear}
+            disabled={!!submitting}
+          >
+            <X />
+          </Button>
+        </div>
+
+        <span aria-hidden className="h-5 w-px bg-foreground/10" />
+
+        <ActionButton
+          icon={<Send />}
+          label="Submit"
+          tooltip={tooltipFor(counts.canSubmit, assets.length, "submit")}
+          disabled={counts.canSubmit === 0 || !!submitting}
+          loading={submitting === "submit"}
+          onClick={() => handleTransition("submit")}
+        />
+        <ActionButton
+          icon={<CheckCircle2 />}
+          label="Approve"
+          tooltip={tooltipFor(counts.canApprove, assets.length, "approve")}
+          disabled={counts.canApprove === 0 || !!submitting}
+          loading={submitting === "approve"}
+          onClick={() => handleTransition("approve")}
+        />
+        <ActionButton
+          icon={<XCircle />}
+          label="Reject"
+          tooltip={tooltipFor(counts.canReject, assets.length, "reject")}
+          disabled={counts.canReject === 0 || !!submitting}
+          loading={submitting === "reject"}
+          onClick={() =>
+            setConfirm({ kind: "reject", count: counts.canReject })
+          }
+        />
+        <ActionButton
+          icon={<Archive />}
+          label="Archive"
+          tooltip={tooltipFor(counts.canArchive, assets.length, "archive")}
+          disabled={counts.canArchive === 0 || !!submitting}
+          loading={submitting === "archive"}
+          onClick={() =>
+            setConfirm({ kind: "archive", count: counts.canArchive })
+          }
+        />
+
+        <span aria-hidden className="h-5 w-px bg-foreground/10" />
+
+        {!lockedBrandId && (
+          <ActionButton
+            icon={<ArrowRightLeft />}
+            label="Move"
+            tooltip={`Move ${assets.length} to brand`}
+            disabled={!!submitting}
+            loading={submitting === "moveBrand"}
+            onClick={() => setBrandPickerOpen(true)}
+          />
+        )}
+        <ActionButton
+          icon={<FolderInput />}
+          label="Campaigns"
+          tooltip={
+            singleBrandId
+              ? `Update campaigns on ${assets.length}`
+              : "Select assets from one brand to assign campaigns"
+          }
+          disabled={!!submitting}
+          loading={submitting === "campaigns"}
+          onClick={() => setCampaignPickerOpen(true)}
+        />
+
+        <span aria-hidden className="h-5 w-px bg-foreground/10" />
+
+        <ActionButton
+          icon={<Trash2 />}
+          label="Delete"
+          tooltip={tooltipFor(counts.canDelete, assets.length, "delete")}
+          variant="destructive"
+          disabled={counts.canDelete === 0 || !!submitting}
+          loading={submitting === "delete"}
+          onClick={() =>
+            setConfirm({ kind: "delete", count: counts.canDelete })
+          }
+        />
+      </div>
+
+      <BulkBrandPicker
+        open={brandPickerOpen}
+        onOpenChange={setBrandPickerOpen}
+        brands={brandOptions}
+        excludeBrandIds={selectionBrandIds}
+        count={assets.length}
+        onConfirm={handleReassign}
+      />
+
+      <BulkCampaignPicker
+        open={campaignPickerOpen}
+        onOpenChange={setCampaignPickerOpen}
+        campaigns={campaignOptions}
+        selectionBrandId={singleBrandId}
+        count={assets.length}
+        onConfirm={handleCampaigns}
+      />
+
+      <Dialog
+        open={!!confirm}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+      >
+        {confirm && (
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{confirmTitle(confirm.kind)}</DialogTitle>
+              <DialogDescription>
+                {confirmDescription(confirm)}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setConfirm(null)}
+                disabled={!!submitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={!!submitting || confirm.count === 0}
+                onClick={async () => {
+                  const kind = confirm.kind;
+                  setConfirm(null);
+                  if (kind === "delete") await handleDelete();
+                  else await handleTransition(kind);
+                }}
+              >
+                {confirmCta(confirm.kind)}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Eligibility — pure helpers. The server is the source of truth; this just
+// dims buttons that have no chance of succeeding for any selected asset.
+// ---------------------------------------------------------------------------
+
+interface EligibilityCounts {
+  canSubmit: number;
+  canApprove: number;
+  canReject: number;
+  canArchive: number;
+  canDelete: number;
+}
+
+function computeCounts(
+  assets: BulkBarAsset[],
+  viewer: BulkActionBarProps["viewer"]
+): EligibilityCounts {
+  let canSubmit = 0;
+  let canApprove = 0;
+  let canReject = 0;
+  let canArchive = 0;
+  let canDelete = 0;
+
+  const isAdmin =
+    viewer.workspaceRole === "owner" || viewer.workspaceRole === "admin";
+
+  for (const a of assets) {
+    if (!a.brandId) continue;
+    const brandRole = viewer.brandRoles[a.brandId] ?? null;
+    const isManager = isAdmin || brandRole === "brand_manager";
+    const isCreator = isManager || brandRole === "creator";
+    const isOwner = a.userId === viewer.userId;
+
+    if (a.status === "draft" && (isManager || (isCreator && isOwner))) {
+      canSubmit += 1;
+    }
+    if (a.status === "in_review" && isManager) {
+      canApprove += 1;
+      canReject += 1;
+    }
+    if (
+      isManager &&
+      (a.status === "draft" ||
+        a.status === "in_review" ||
+        a.status === "approved" ||
+        a.status === "rejected")
+    ) {
+      canArchive += 1;
+    }
+    if (a.status !== "approved" && (isOwner || isManager)) {
+      canDelete += 1;
+    }
+  }
+
+  return { canSubmit, canApprove, canReject, canArchive, canDelete };
+}
+
+function tooltipFor(eligible: number, total: number, verb: string): string {
+  if (eligible === 0) {
+    return `Nothing to ${verb} in this selection`;
+  }
+  if (eligible === total) {
+    return `${verb[0].toUpperCase() + verb.slice(1)} ${total}`;
+  }
+  return `${eligible} of ${total} selected can be ${pastTense(verb)}`;
+}
+
+function pastTense(verb: string): string {
+  switch (verb) {
+    case "submit":
+      return "submitted";
+    case "approve":
+      return "approved";
+    case "reject":
+      return "rejected";
+    case "archive":
+      return "archived";
+    case "delete":
+      return "deleted";
+    default:
+      return verb + "ed";
+  }
+}
+
+function confirmTitle(kind: ConfirmState["kind"]): string {
+  switch (kind) {
+    case "reject":
+      return "Reject selected assets?";
+    case "archive":
+      return "Archive selected assets?";
+    case "delete":
+      return "Delete selected assets?";
+  }
+}
+
+function confirmDescription(confirm: ConfirmState): string {
+  if (confirm.count === 0) {
+    return "Nothing in your selection is eligible for this action.";
+  }
+  switch (confirm.kind) {
+    case "reject":
+      return `${confirm.count} ${confirm.count === 1 ? "asset" : "assets"} will be rejected. The submitter will be notified.`;
+    case "archive":
+      return `${confirm.count} ${confirm.count === 1 ? "asset" : "assets"} will be archived. You can unarchive later from the asset detail panel.`;
+    case "delete":
+      return `${confirm.count} ${confirm.count === 1 ? "asset" : "assets"} will be permanently deleted. Approved assets are not deleted; archive them instead.`;
+  }
+}
+
+function confirmCta(kind: ConfirmState["kind"]): string {
+  switch (kind) {
+    case "reject":
+      return "Reject";
+    case "archive":
+      return "Archive";
+    case "delete":
+      return "Delete";
+  }
+}
+
+function summarizeToast(kind: BulkActionKind, result: BulkServerResult): void {
+  const verb = pastTense(actionVerb(kind));
+  if (result.failed.length === 0) {
+    toast.success(`${result.succeeded.length} ${verb}.`);
+    return;
+  }
+  if (result.succeeded.length === 0) {
+    const sample = result.failed[0]?.code ?? "failed";
+    toast.error(`Couldn't ${actionVerb(kind)} ${result.failed.length}: ${humanizeCode(sample)}`);
+    return;
+  }
+  const sample = result.failed[0]?.code ?? "failed";
+  toast.message(
+    `${result.succeeded.length} ${verb}, ${result.failed.length} failed: ${humanizeCode(sample)}`
+  );
+}
+
+function actionVerb(kind: BulkActionKind): string {
+  switch (kind) {
+    case "submit":
+      return "submit";
+    case "approve":
+      return "approve";
+    case "reject":
+      return "reject";
+    case "archive":
+      return "archive";
+    case "delete":
+      return "delete";
+    case "moveBrand":
+      return "move";
+    case "campaigns":
+      return "update";
+  }
+}
+
+function humanizeCode(code: string): string {
+  switch (code) {
+    case "asset_immutable":
+    case "approved_immutable_fork_required":
+      return "approved assets must be forked";
+    case "forbidden":
+      return "permission denied";
+    case "not_found":
+      return "asset not found";
+    case "invalid_transition":
+      return "not in the right state";
+    case "personal_brand_no_review":
+      return "personal-brand assets can't enter review";
+    case "self_approval_blocked":
+      return "self-approval is disabled";
+    case "campaigns_not_in_brand":
+      return "some campaigns don't belong to that brand";
+    case "cross_workspace_move_forbidden":
+      return "cross-workspace move blocked";
+    default:
+      return code.replaceAll("_", " ");
+  }
+}
+
+async function callBulk(
+  url: string,
+  method: "POST" | "PATCH" | "DELETE",
+  body: unknown
+): Promise<BulkServerResult> {
+  const res = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`bulk request failed: ${res.status}`);
+  }
+  return (await res.json()) as BulkServerResult;
+}
+
+// ---------------------------------------------------------------------------
+// Action button — small icon button with an inline tooltip.
+// ---------------------------------------------------------------------------
+
+function ActionButton({
+  icon,
+  label,
+  tooltip,
+  disabled,
+  loading,
+  onClick,
+  variant = "ghost",
+}: {
+  icon: React.ReactNode;
+  label: string;
+  tooltip: string;
+  disabled?: boolean;
+  loading?: boolean;
+  onClick: () => void;
+  variant?: "ghost" | "destructive";
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant={variant}
+            size="sm"
+            disabled={disabled || loading}
+            onClick={onClick}
+            aria-label={label}
+          />
+        }
+      >
+        {icon}
+        <span className="hidden sm:inline">{label}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/bulk/bulk-brand-picker.tsx
+++ b/src/components/bulk/bulk-brand-picker.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { BrandMark } from "@/components/brand-mark";
+import { cn } from "@/lib/utils";
+
+export interface BulkBrandOption {
+  id: string;
+  name: string;
+  color: string;
+  isPersonal?: boolean;
+  logoUrl?: string | null;
+  ownerImage?: string | null;
+}
+
+interface BulkBrandPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  brands: BulkBrandOption[];
+  /** Brand ids the user already has selected from — those are filtered out
+   *  of the destination list (a no-op move would just fail). */
+  excludeBrandIds?: string[];
+  count: number;
+  onConfirm: (brandId: string) => Promise<void>;
+}
+
+export function BulkBrandPicker({
+  open,
+  onOpenChange,
+  brands,
+  excludeBrandIds = [],
+  count,
+  onConfirm,
+}: BulkBrandPickerProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const exclude = new Set(excludeBrandIds);
+  // Personal brands are always invalid as a destination — server rejects too,
+  // but hiding them keeps the picker honest.
+  const eligible = brands.filter(
+    (b) => !b.isPersonal && !exclude.has(b.id)
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!submitting) onOpenChange(next);
+        if (!next) setSelected(null);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Move to brand</DialogTitle>
+          <DialogDescription>
+            Move {count} {count === 1 ? "asset" : "assets"} to another brand.
+            Status resets to draft so the destination team can review.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[320px] overflow-y-auto rounded-lg ring-1 ring-foreground/10">
+          {eligible.length === 0 ? (
+            <div className="p-6 text-center text-sm text-muted-foreground">
+              No eligible destination brands.
+            </div>
+          ) : (
+            <ul className="divide-y divide-foreground/5">
+              {eligible.map((brand) => {
+                const active = selected === brand.id;
+                return (
+                  <li key={brand.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(brand.id)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-3 py-2 text-left text-sm",
+                        "hover:bg-muted/40",
+                        active && "bg-primary/10 text-primary"
+                      )}
+                      aria-pressed={active}
+                    >
+                      <BrandMark brand={brand} size="xs" />
+                      <span className="flex-1 truncate">{brand.name}</span>
+                      {active ? (
+                        <svg
+                          aria-hidden
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="size-3.5"
+                        >
+                          <path d="M3 8l3 3 7-7" />
+                        </svg>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!selected || submitting}
+            onClick={async () => {
+              if (!selected) return;
+              setSubmitting(true);
+              try {
+                await onConfirm(selected);
+                onOpenChange(false);
+              } finally {
+                setSubmitting(false);
+                setSelected(null);
+              }
+            }}
+          >
+            {submitting ? "Moving…" : "Move"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bulk/bulk-campaign-picker.tsx
+++ b/src/components/bulk/bulk-campaign-picker.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import type { CampaignMode } from "@/lib/assets/mutations";
+
+export interface BulkCampaignOption {
+  id: string;
+  name: string;
+  brandId: string;
+}
+
+interface BulkCampaignPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** All campaigns the user can see. Filtered down to the brand of the
+   *  current selection at render time. */
+  campaigns: BulkCampaignOption[];
+  /**
+   * The brand of the entire selection. `null` means the selection spans
+   * multiple brands (or has no brand) and the picker shows a guard message
+   * instead — campaigns are brand-scoped in schema and a cross-brand assign
+   * would just fail at the API.
+   */
+  selectionBrandId: string | null;
+  count: number;
+  onConfirm: (input: {
+    campaignIds: string[];
+    mode: CampaignMode;
+  }) => Promise<void>;
+}
+
+export function BulkCampaignPicker({
+  open,
+  onOpenChange,
+  campaigns,
+  selectionBrandId,
+  count,
+  onConfirm,
+}: BulkCampaignPickerProps) {
+  const [mode, setMode] = useState<CampaignMode>("add");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (submitting) return;
+    if (!next) {
+      // Reset state on close so a previous mode/selection doesn't leak
+      // between opens — done eagerly on close (not in an effect) to avoid
+      // cascading-render lint warnings.
+      setSelected(new Set());
+      setMode("add");
+    }
+    onOpenChange(next);
+  };
+
+  const eligibleCampaigns = selectionBrandId
+    ? campaigns.filter((c) => c.brandId === selectionBrandId)
+    : [];
+
+  const canConfirm =
+    !!selectionBrandId &&
+    !submitting &&
+    (mode === "set"
+      ? true // set with empty list = clear all campaigns; valid action.
+      : selected.size > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Assign campaigns</DialogTitle>
+          <DialogDescription>
+            Update campaigns on {count} {count === 1 ? "asset" : "assets"}.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!selectionBrandId ? (
+          <div className="rounded-lg bg-muted/40 p-4 text-sm text-muted-foreground">
+            Select assets from one brand to assign campaigns. Campaigns are
+            brand-scoped, so cross-brand selections aren&apos;t supported.
+          </div>
+        ) : (
+          <>
+            <div
+              role="radiogroup"
+              aria-label="Mode"
+              className="grid grid-cols-3 gap-1 rounded-lg bg-muted p-1 text-sm"
+            >
+              {(
+                [
+                  { value: "add", label: "Add" },
+                  { value: "remove", label: "Remove" },
+                  { value: "set", label: "Replace" },
+                ] as { value: CampaignMode; label: string }[]
+              ).map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={mode === opt.value}
+                  onClick={() => setMode(opt.value)}
+                  className={cn(
+                    "rounded-md px-2 py-1.5 font-medium",
+                    mode === opt.value
+                      ? "bg-background text-foreground ring-1 ring-foreground/10"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="max-h-[280px] overflow-y-auto rounded-lg ring-1 ring-foreground/10">
+              {eligibleCampaigns.length === 0 ? (
+                <div className="p-6 text-center text-sm text-muted-foreground">
+                  No campaigns in this brand yet.
+                </div>
+              ) : (
+                <ul className="divide-y divide-foreground/5">
+                  {eligibleCampaigns.map((campaign) => {
+                    const active = selected.has(campaign.id);
+                    return (
+                      <li key={campaign.id}>
+                        <button
+                          type="button"
+                          role="checkbox"
+                          aria-checked={active}
+                          onClick={() => {
+                            setSelected((prev) => {
+                              const next = new Set(prev);
+                              if (next.has(campaign.id)) {
+                                next.delete(campaign.id);
+                              } else {
+                                next.add(campaign.id);
+                              }
+                              return next;
+                            });
+                          }}
+                          className={cn(
+                            "flex w-full items-center gap-3 px-3 py-2 text-left text-sm",
+                            "hover:bg-muted/40",
+                            active && "bg-primary/10 text-primary"
+                          )}
+                        >
+                          <span
+                            aria-hidden
+                            className={cn(
+                              "flex size-4 items-center justify-center rounded-sm border",
+                              active
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : "border-foreground/25"
+                            )}
+                          >
+                            {active && (
+                              <svg
+                                viewBox="0 0 16 16"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth={2.5}
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                className="size-3"
+                              >
+                                <path d="M3 8l3 3 7-7" />
+                              </svg>
+                            )}
+                          </span>
+                          <span className="flex-1 truncate">
+                            {campaign.name}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!canConfirm}
+            onClick={async () => {
+              setSubmitting(true);
+              try {
+                await onConfirm({
+                  campaignIds: Array.from(selected),
+                  mode,
+                });
+                handleOpenChange(false);
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {submitting ? "Saving…" : "Apply"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bulk/bulk-select-checkbox.tsx
+++ b/src/components/bulk/bulk-select-checkbox.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Custom checkbox surfaced over each grid card. Mirrors the visual contract
+ * of `CheckboxRow` in `library/filter-bar.tsx` — a small filled-square check,
+ * with `bg-primary` when active. Hidden by default; revealed on hover, when
+ * the card is focused, or when at least one item is already selected (so
+ * users can click any checkbox without first hovering it).
+ */
+
+interface BulkSelectCheckboxProps {
+  checked: boolean;
+  onToggle: (event: { shiftKey?: boolean }) => void;
+  /** True when selection is non-empty — keeps the checkbox visible after the
+   *  first click so further multi-selects don't require hover precision. */
+  alwaysVisible?: boolean;
+  className?: string;
+  label?: string;
+}
+
+export function BulkSelectCheckbox({
+  checked,
+  onToggle,
+  alwaysVisible,
+  className,
+  label = "Select",
+}: BulkSelectCheckboxProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={(e) => {
+        // Don't bubble — the parent card has its own click handler that opens
+        // the detail panel.
+        e.stopPropagation();
+        onToggle({ shiftKey: e.shiftKey });
+      }}
+      onPointerDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          onToggle({ shiftKey: e.shiftKey });
+        }
+      }}
+      data-slot="bulk-select-checkbox"
+      data-state={checked ? "checked" : "unchecked"}
+      className={cn(
+        "absolute left-2 top-2 z-20 inline-flex size-5 items-center justify-center rounded-md ring-1 ring-foreground/15 backdrop-blur-sm",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+        checked
+          ? "bg-primary text-primary-foreground ring-primary opacity-100"
+          : "bg-background/80 text-foreground opacity-0 group-hover/card:opacity-100 group-focus-within/card:opacity-100",
+        alwaysVisible && !checked && "opacity-100",
+        className
+      )}
+    >
+      {checked ? (
+        <svg
+          aria-hidden
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-3"
+        >
+          <path d="M3 8l3 3 7-7" />
+        </svg>
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/bulk/use-bulk-selection.ts
+++ b/src/components/bulk/use-bulk-selection.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * Generic multi-select primitive for grid views (Library, Gallery).
+ *
+ * Behavior:
+ *   - Click to toggle one id.
+ *   - Shift-click extends from the last toggled id to the new id, inclusive,
+ *     in the order the items array was passed in. Range mode adds (never
+ *     removes) so the caller can build the selection up.
+ *   - Cmd/Ctrl+A selects every visible (currently-loaded) item, scoped via
+ *     the `containerRef` so selection only fires when focus is inside.
+ *   - Esc clears the selection.
+ *   - When the items list changes (e.g. filter swap, cursor refetch), any
+ *     selected ids that no longer appear are dropped automatically — the bar
+ *     never acts on assets the user can't see.
+ */
+
+export interface BulkSelection {
+  selectedIds: Set<string>;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string, event?: { shiftKey?: boolean }) => void;
+  selectAllVisible: () => void;
+  clear: () => void;
+  count: number;
+}
+
+export interface UseBulkSelectionOptions {
+  /** Ref of the surface that should anchor keyboard shortcuts. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /**
+   * Optional disable flag — useful when a modal is open over the grid and
+   * we don't want Cmd+A / Esc to fight with form fields.
+   */
+  enabled?: boolean;
+}
+
+export function useBulkSelection<T>(
+  items: T[],
+  getId: (item: T) => string,
+  options: UseBulkSelectionOptions
+): BulkSelection {
+  const { containerRef, enabled = true } = options;
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const anchorRef = useRef<string | null>(null);
+
+  const getIdRef = useRef(getId);
+  getIdRef.current = getId;
+  const idList = useMemo(() => items.map((item) => getIdRef.current(item)), [items]);
+
+  // Render-time prune: if the id list reference changed, drop any selected
+  // ids that vanished. Mirrors the previous-prop sentinel pattern used in
+  // library-asset-picker-dialog.tsx so we don't trip
+  // `react-hooks/set-state-in-effect`.
+  const [prevIdList, setPrevIdList] = useState<string[]>(idList);
+  if (prevIdList !== idList) {
+    setPrevIdList(idList);
+    setSelectedIds((current) => {
+      if (current.size === 0) return current;
+      const visible = new Set(idList);
+      let mutated = false;
+      const next = new Set<string>();
+      for (const id of current) {
+        if (visible.has(id)) next.add(id);
+        else mutated = true;
+      }
+      return mutated ? next : current;
+    });
+  }
+
+  const toggle = useCallback(
+    (id: string, event?: { shiftKey?: boolean }) => {
+      const ids = idList;
+      if (event?.shiftKey && anchorRef.current) {
+        const start = ids.indexOf(anchorRef.current);
+        const end = ids.indexOf(id);
+        if (start >= 0 && end >= 0) {
+          const [lo, hi] = start <= end ? [start, end] : [end, start];
+          setSelectedIds((prev) => {
+            const next = new Set(prev);
+            for (let i = lo; i <= hi; i++) next.add(ids[i]);
+            return next;
+          });
+          anchorRef.current = id;
+          return;
+        }
+      }
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+      anchorRef.current = id;
+    },
+    [idList]
+  );
+
+  const selectAllVisible = useCallback(() => {
+    setSelectedIds(new Set(idList));
+    anchorRef.current = idList[0] ?? null;
+  }, [idList]);
+
+  const clear = useCallback(() => {
+    setSelectedIds(new Set());
+    anchorRef.current = null;
+  }, []);
+
+  // Keyboard shortcuts. Cmd/Ctrl+A only fires when the container has focus
+  // (or contains the active element) so we don't hijack the page-level
+  // browser shortcut when the user is focused in a search input outside the
+  // grid.
+  useEffect(() => {
+    if (!enabled) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const target = e.target as Node | null;
+      const inContainer =
+        target instanceof Node &&
+        (container === target || container.contains(target));
+      if (!inContainer) return;
+
+      // Don't hijack typing in inputs/textareas/contenteditable.
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a") {
+        if (idList.length === 0) return;
+        e.preventDefault();
+        selectAllVisible();
+        return;
+      }
+      if (e.key === "Escape") {
+        if (selectedIds.size === 0) return;
+        e.preventDefault();
+        clear();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [containerRef, enabled, idList, selectAllVisible, clear, selectedIds]);
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds]
+  );
+
+  return {
+    selectedIds,
+    isSelected,
+    toggle,
+    selectAllVisible,
+    clear,
+    count: selectedIds.size,
+  };
+}

--- a/src/components/review-modal.tsx
+++ b/src/components/review-modal.tsx
@@ -31,6 +31,7 @@ import {
   nextNonDecisionedIndex,
 } from "@/components/review-filmstrip";
 import { ThreadPanel } from "@/components/threads/thread-panel";
+import { CampaignPicker } from "@/components/asset/campaign-picker";
 
 export interface ReviewQueueItem {
   id: string;
@@ -58,6 +59,11 @@ export interface ReviewQueueItem {
 interface ReviewModalProps {
   open: boolean;
   queue: ReviewQueueItem[];
+  /**
+   * Brand the queue belongs to. Used by the inline campaign picker to scope
+   * its option list and to gate visibility on the viewer's brand role.
+   */
+  brandId: string;
   index: number;
   onIndexChange: (next: number) => void;
   onAction: (
@@ -65,6 +71,15 @@ interface ReviewModalProps {
     item: ReviewQueueItem,
     note: string | undefined
   ) => Promise<void> | void;
+  /**
+   * Called when the user edits campaign tags from inside the modal. Lets the
+   * parent keep its `queue`/`displayQueue` state in sync so the filmstrip and
+   * the next reviewer surface see the change.
+   */
+  onCampaignsChange?: (
+    itemId: string,
+    next: { id: string; name: string }[]
+  ) => void;
   onClose: () => void;
   /**
    * Stable snapshot of the queue captured when the modal opened. The filmstrip
@@ -97,9 +112,11 @@ const EMPTY_DECISIONS: Map<string, "approved" | "rejected"> = new Map();
 export function ReviewModal({
   open,
   queue,
+  brandId,
   index,
   onIndexChange,
   onAction,
+  onCampaignsChange,
   onClose,
   displayQueue,
   sessionDecisions,
@@ -333,6 +350,12 @@ export function ReviewModal({
               <Field label="Campaign">
                 <CampaignMetadata campaigns={item.campaigns} />
               </Field>
+              <CampaignPicker
+                assetId={item.id}
+                brandId={brandId}
+                campaigns={item.campaigns}
+                onChange={(next) => onCampaignsChange?.(item.id, next)}
+              />
               <Field label="Prompt">
                 <p className="whitespace-pre-wrap text-foreground">
                   {item.prompt}

--- a/src/lib/assets/mutations.ts
+++ b/src/lib/assets/mutations.ts
@@ -1,0 +1,462 @@
+/**
+ * Shared per-asset mutation helpers.
+ *
+ * These extract the per-asset logic out of the `[id]/*` routes so the bulk
+ * endpoints can run them in a tight loop without re-loading per-request
+ * context (auth session, RoleContext, BrandContext) for every id.
+ *
+ * Each helper accepts pre-loaded contexts and throws `AssetMutationError` on
+ * any user-visible failure. Bulk callers catch and surface in `failed[]`;
+ * single-asset callers translate to the shape the existing route returned.
+ */
+
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  assetCampaigns,
+  assets,
+  brands as brandsTable,
+  campaigns,
+} from "@/lib/db/schema";
+import { deleteFile } from "@/lib/storage";
+import {
+  createNotification,
+  createNotifications,
+  loadSubmitRecipients,
+  type NotificationInput,
+} from "@/lib/notifications";
+import {
+  checkTransitionPermission,
+  logReviewEvent,
+  TransitionError,
+  transitionAsset,
+  type TransitionAction,
+} from "@/lib/transitions";
+import {
+  canCreateAsset,
+  isBrandManager,
+  isWorkspaceAdmin,
+  type BrandContext,
+  type RoleContext,
+} from "@/lib/workspace/permissions";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class AssetMutationError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status: number
+  ) {
+    super(message);
+    this.name = "AssetMutationError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared asset shape — minimum required fields per helper. Bulk callers
+// hydrate this once with a single SELECT for all ids; single-asset callers
+// load the row inline.
+// ---------------------------------------------------------------------------
+
+export interface MutableAsset {
+  id: string;
+  userId: string;
+  brandId: string | null;
+  status: "draft" | "in_review" | "approved" | "rejected" | "archived";
+  prompt: string;
+  r2Key: string;
+  thumbnailR2Key: string | null;
+  webpR2Key: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Transition (submit / approve / reject / archive / unarchive)
+// ---------------------------------------------------------------------------
+
+export interface TransitionMutationInput {
+  asset: MutableAsset;
+  action: TransitionAction;
+  ctx: RoleContext;
+  brandCtx: BrandContext;
+  actorId: string;
+  note?: string;
+}
+
+export interface TransitionMutationResult {
+  assetId: string;
+  fromStatus: MutableAsset["status"];
+  toStatus: MutableAsset["status"];
+}
+
+export async function transitionAssetMutation(
+  input: TransitionMutationInput
+): Promise<TransitionMutationResult> {
+  const { asset, action, ctx, brandCtx, actorId, note } = input;
+
+  if (!asset.brandId) {
+    throw new AssetMutationError(
+      "asset_missing_brand",
+      "Asset has no brand context",
+      409
+    );
+  }
+
+  // Synthesize creator role on Personal brand if the membership row is missing
+  // — mirrors the carve-out in /api/generate so users always control their own
+  // scratch space.
+  if (
+    brandCtx.isPersonal &&
+    brandCtx.ownerId === actorId &&
+    !ctx.brandMemberships.has(brandCtx.id)
+  ) {
+    ctx.brandMemberships.set(brandCtx.id, "creator");
+  }
+
+  const allowed = checkTransitionPermission(action, ctx, asset, brandCtx);
+  if (!allowed.ok) {
+    throw new AssetMutationError(allowed.code, allowed.code, allowed.status);
+  }
+
+  try {
+    const result = await transitionAsset({
+      assetId: asset.id,
+      actorId,
+      action,
+      note,
+    });
+
+    // Best-effort fan-out — match the single-asset route's fire-and-forget
+    // pattern. A notification write failure must not cascade into the bulk
+    // result; the audit log is the system of record.
+    void fanOutNotifications({
+      action,
+      actorId,
+      asset: { id: asset.id, userId: asset.userId, prompt: asset.prompt },
+      brand: { id: brandCtx.id, workspaceId: brandCtx.workspaceId },
+      note,
+    }).catch((err) => {
+      console.error("notifications.fanOut failed", err);
+    });
+
+    return {
+      assetId: result.assetId,
+      fromStatus: result.fromStatus,
+      toStatus: result.toStatus,
+    };
+  } catch (err) {
+    if (err instanceof TransitionError) {
+      throw new AssetMutationError(err.code, err.message, err.status);
+    }
+    throw err;
+  }
+}
+
+interface FanOutInput {
+  action: TransitionAction;
+  actorId: string;
+  asset: { id: string; userId: string; prompt: string };
+  brand: { id: string; workspaceId: string };
+  note?: string;
+}
+
+async function fanOutNotifications(input: FanOutInput): Promise<void> {
+  const { action, actorId, asset, brand, note } = input;
+  if (action !== "submit" && action !== "approve" && action !== "reject") {
+    return;
+  }
+
+  const [brandRow] = await db
+    .select({ slug: brandsTable.slug, name: brandsTable.name })
+    .from(brandsTable)
+    .where(eq(brandsTable.id, brand.id))
+    .limit(1);
+  const brandSlug = brandRow?.slug ?? brand.id;
+  const brandName = brandRow?.name ?? null;
+  const reviewHref = `/brands/${brandSlug}/review`;
+  const assetTitle = excerpt(asset.prompt);
+
+  if (action === "submit") {
+    const recipients = await loadSubmitRecipients({
+      actorId,
+      brandId: brand.id,
+      workspaceId: brand.workspaceId,
+    });
+    const inputs: NotificationInput[] = recipients.map((userId) => ({
+      userId,
+      workspaceId: brand.workspaceId,
+      actorId,
+      type: "asset_submitted",
+      payload: {
+        assetId: asset.id,
+        brandId: brand.id,
+        brandName,
+        assetTitle,
+      },
+      href: reviewHref,
+    }));
+    await createNotifications(inputs);
+    return;
+  }
+
+  if (asset.userId === actorId) return;
+
+  await createNotification({
+    userId: asset.userId,
+    workspaceId: brand.workspaceId,
+    actorId,
+    type: action === "approve" ? "asset_approved" : "asset_rejected",
+    payload: {
+      assetId: asset.id,
+      brandId: brand.id,
+      brandName,
+      assetTitle,
+      ...(note ? { note } : {}),
+    },
+    href: reviewHref,
+  });
+}
+
+function excerpt(text: string, max = 80): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1) + "…";
+}
+
+// ---------------------------------------------------------------------------
+// Reassign brand
+// ---------------------------------------------------------------------------
+
+export interface ReassignBrandInput {
+  asset: MutableAsset;
+  targetBrandId: string;
+  ctx: RoleContext;
+  sourceBrandCtx: BrandContext;
+  destBrandCtx: BrandContext;
+  actorId: string;
+}
+
+export interface ReassignBrandResult {
+  assetId: string;
+  brandId: string;
+  status: "draft";
+}
+
+export async function reassignAssetBrand(
+  input: ReassignBrandInput
+): Promise<ReassignBrandResult> {
+  const { asset, targetBrandId, ctx, sourceBrandCtx, destBrandCtx, actorId } =
+    input;
+
+  if (asset.status === "approved") {
+    throw new AssetMutationError(
+      "approved_immutable_fork_required",
+      "Approved assets are immutable; fork to edit.",
+      409
+    );
+  }
+  if (!asset.brandId) {
+    throw new AssetMutationError(
+      "source_workspace_missing",
+      "Asset has no source brand",
+      500
+    );
+  }
+  if (asset.brandId === targetBrandId) {
+    throw new AssetMutationError(
+      "target_same_as_source",
+      "Source and destination brands are the same",
+      400
+    );
+  }
+
+  // Source permission gate.
+  const isCreatorOfAsset = asset.userId === actorId;
+  const sourceAllowed =
+    isCreatorOfAsset ||
+    isBrandManager(ctx, sourceBrandCtx.id) ||
+    isWorkspaceAdmin(ctx);
+  if (!sourceAllowed) {
+    throw new AssetMutationError("forbidden", "Forbidden", 403);
+  }
+
+  if (destBrandCtx.workspaceId !== sourceBrandCtx.workspaceId) {
+    throw new AssetMutationError(
+      "cross_workspace_move_forbidden",
+      "Cross-workspace move is not allowed",
+      403
+    );
+  }
+  if (destBrandCtx.isPersonal) {
+    throw new AssetMutationError(
+      "target_must_be_real_brand",
+      "Destination must be a non-Personal brand",
+      400
+    );
+  }
+
+  // Destination permission gate — must be creator+ on destination.
+  if (!canCreateAsset(ctx, destBrandCtx)) {
+    throw new AssetMutationError("forbidden", "Forbidden", 403);
+  }
+
+  const fromStatus = asset.status;
+
+  await db
+    .update(assets)
+    .set({ brandId: targetBrandId, status: "draft", updatedAt: new Date() })
+    .where(eq(assets.id, asset.id));
+
+  await logReviewEvent({
+    assetId: asset.id,
+    actorId,
+    action: "moved_brand",
+    fromStatus,
+    toStatus: "draft",
+  });
+
+  return { assetId: asset.id, brandId: targetBrandId, status: "draft" };
+}
+
+// ---------------------------------------------------------------------------
+// Set / add / remove campaigns
+// ---------------------------------------------------------------------------
+
+export type CampaignMode = "set" | "add" | "remove";
+
+export interface SetAssetCampaignsInput {
+  asset: MutableAsset;
+  brandCtx: BrandContext;
+  ctx: RoleContext;
+  campaignIds: string[];
+  mode: CampaignMode;
+}
+
+export interface SetAssetCampaignsResult {
+  assetId: string;
+  campaignIds: string[];
+}
+
+export async function setAssetCampaigns(
+  input: SetAssetCampaignsInput
+): Promise<SetAssetCampaignsResult> {
+  const { asset, brandCtx, ctx, campaignIds, mode } = input;
+
+  if (!canCreateAsset(ctx, brandCtx)) {
+    throw new AssetMutationError("forbidden", "Forbidden", 403);
+  }
+
+  const desired = Array.from(new Set(campaignIds));
+
+  // All campaign ids must belong to the asset's brand. Catches typos and
+  // cross-brand leakage; matches the single-asset route's guard.
+  if (desired.length > 0) {
+    const valid = await db
+      .select({ id: campaigns.id })
+      .from(campaigns)
+      .where(
+        and(eq(campaigns.brandId, brandCtx.id), inArray(campaigns.id, desired))
+      );
+    if (valid.length !== desired.length) {
+      throw new AssetMutationError(
+        "campaigns_not_in_brand",
+        "Some campaigns do not belong to the asset's brand",
+        400
+      );
+    }
+  }
+
+  if (mode === "set") {
+    await db.delete(assetCampaigns).where(eq(assetCampaigns.assetId, asset.id));
+    if (desired.length > 0) {
+      await db
+        .insert(assetCampaigns)
+        .values(desired.map((cid) => ({ assetId: asset.id, campaignId: cid })));
+    }
+    return { assetId: asset.id, campaignIds: desired };
+  }
+
+  if (mode === "add") {
+    if (desired.length > 0) {
+      await db
+        .insert(assetCampaigns)
+        .values(desired.map((cid) => ({ assetId: asset.id, campaignId: cid })))
+        .onConflictDoNothing();
+    }
+  } else {
+    if (desired.length > 0) {
+      await db
+        .delete(assetCampaigns)
+        .where(
+          and(
+            eq(assetCampaigns.assetId, asset.id),
+            inArray(assetCampaigns.campaignId, desired)
+          )
+        );
+    }
+  }
+
+  // Return the final set of campaigns so callers can reflect state
+  // accurately after add/remove.
+  const finalRows = await db
+    .select({ campaignId: assetCampaigns.campaignId })
+    .from(assetCampaigns)
+    .where(eq(assetCampaigns.assetId, asset.id));
+  return {
+    assetId: asset.id,
+    campaignIds: finalRows.map((r) => r.campaignId),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Delete asset
+// ---------------------------------------------------------------------------
+
+export interface DeleteAssetInput {
+  asset: MutableAsset;
+  ctx: RoleContext;
+  brandCtx: BrandContext | null;
+  actorId: string;
+}
+
+export async function deleteAsset(input: DeleteAssetInput): Promise<void> {
+  const { asset, ctx, brandCtx, actorId } = input;
+
+  if (asset.status === "approved") {
+    throw new AssetMutationError(
+      "asset_immutable",
+      "Approved assets are immutable; archive instead.",
+      409
+    );
+  }
+
+  // Permission check the single-asset route was missing — creator OR
+  // brand_manager on the asset's brand OR workspace owner/admin.
+  const isCreator = asset.userId === actorId;
+  const allowed =
+    isCreator ||
+    isWorkspaceAdmin(ctx) ||
+    (brandCtx ? isBrandManager(ctx, brandCtx.id) : false);
+  if (!allowed) {
+    throw new AssetMutationError("forbidden", "Forbidden", 403);
+  }
+
+  // Delete from storage. Best-effort — orphaned R2 objects are recoverable
+  // out-of-band; failing the user-facing delete because of a transient R2
+  // hiccup is the worse outcome.
+  try {
+    await deleteFile(asset.r2Key);
+    if (asset.thumbnailR2Key) {
+      await deleteFile(asset.thumbnailR2Key);
+    }
+    if (asset.webpR2Key) {
+      await deleteFile(asset.webpR2Key);
+    }
+  } catch (error) {
+    console.error("Failed to delete from storage:", error);
+  }
+
+  await db.delete(assets).where(eq(assets.id, asset.id));
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,26 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: "2026-05-07",
+    title: "Bulk actions in Library and Gallery",
+    bullets: [
+      "Hover any card to reveal a checkbox — click to select, shift-click to extend a range, ⌘/Ctrl+A to select everything loaded, Esc to clear",
+      "A floating action bar shows up the moment you select something — submit, approve, reject, archive, delete, move to brand, or assign campaigns to the whole batch in one go",
+      "Buttons that don't apply to your selection dim with a count tooltip (e.g. \"3 of 7 can be approved\") so you know exactly what an action will affect",
+      "Approved assets stay protected — bulk delete and bulk move skip them and tell you which ones need a fork",
+      "Brand Gallery hides \"Move to brand\" since the brand is already locked, but every other bulk action works there too",
+    ],
+  },
+  {
+    date: "2026-05-07",
+    title: "Tag assets to campaigns from anywhere",
+    bullets: [
+      "The campaign picker now appears in the review modal, so brand managers and creators can group assets while triaging — no need to wait for approval or jump back to the library",
+      "After a generation finishes, a campaign picker shows up next to the brand and brew controls so you can tag the result before it moves through review",
+      "Tightened who can tag: only creators, brand managers, and workspace admins/owners see the picker — viewers no longer have an editing affordance (the server already enforced this)",
+    ],
+  },
+  {
     date: "2026-05-02",
     title: "Activity feed — see what's happening across your workspace",
     bullets: [


### PR DESCRIPTION
## Summary

- Adds multi-select + bulk actions to **Library**, **Gallery**, and **Brand Gallery**.
- Hover-revealed checkboxes; shift-click ranges; `Cmd/Ctrl+A` selects loaded items only; `Esc` clears.
- Sticky **action bar** offers: move to brand, assign campaigns (set / add / remove), submit, approve, reject, archive, delete.
- New `/api/assets/bulk/*` endpoints. Each accepts `{ ids }` (capped at 200) and returns `{ requested, succeeded, failed }` so partial failures (approved-immutable, mixed-state, mixed-permission) surface in a toast instead of failing the whole batch.
- Existing single-asset routes refactored to call shared helpers in `src/lib/assets/mutations.ts` — response shapes preserved byte-for-byte.
- Closes a latent gap: the single-asset `DELETE /api/assets/[id]` had no per-asset auth check; the shared helper now enforces creator OR `isBrandManager` OR `isWorkspaceAdmin`.

### Bonus surfaces (rode along on the campaign-picker extraction)
- The library detail-panel's inline `CampaignPicker` is extracted into `src/components/asset/campaign-picker.tsx`.
- It's now used in: bulk-campaign-picker, the **generate result panel** (campaign tagger after a non-personal generation), and the **review modal** (inline campaign editing while reviewing).

### Files
- New: `src/lib/assets/mutations.ts`, `src/app/api/assets/bulk/{transition,reassign-brand,campaigns,route}.ts`, `src/components/bulk/{use-bulk-selection,bulk-select-checkbox,bulk-action-bar,bulk-brand-picker,bulk-campaign-picker}.{ts,tsx}`, `src/components/asset/campaign-picker.tsx`
- Modified: 4 single-asset routes, `library-client.tsx`, `gallery-client.tsx`, `library/detail-panel.tsx`, `generate-client.tsx`, `review-client.tsx`, `review-modal.tsx`, `src/lib/changelog.ts`

### History note
This work was originally pushed straight to main (`b5abb81`), then reverted on main (`0dae968`) and cherry-picked here so it could route through PR review. Net diff against main is identical to the original commit's content.

### Deferred to a follow-up
- **Bulk download** — needs a streaming-zip utility (e.g. `archiver`); kept this PR focused.

## Test plan

- [ ] **Library** (`/library`): hover a card → checkbox appears; click two → bar shows count 2; shift-click a third 5 cards down → range select.
- [ ] `Cmd/Ctrl+A` selects all loaded assets; `Esc` clears.
- [ ] **Move to brand**: select 5 across brands, choose target → toast; verify cards reflect the new brand; verify approved asset stays put with reason in toast.
- [ ] **Assign campaigns** (set / add / remove): select within one brand → verify in detail panel; multi-brand selection shows the guard message rather than calling the API.
- [ ] **Submit / Approve / Reject**: mixed-state selections → only-eligible behavior; activity feed + notifications fire per asset.
- [ ] **Archive / Delete**: confirm sheet shows correct count; partial failure (mix in an approved asset) surfaces "1 failed: approved assets must be forked".
- [ ] **Brand Gallery** (`/brands/<slug>/gallery`): "Move to brand" hidden; everything else works.
- [ ] Permission spot-check: as a Creator (not Manager) on a brand — Approve hidden, Reject hidden, Submit visible.
- [ ] **Bonus**: campaign tagger appears on the generate result; review modal lets you edit campaigns inline.
- [ ] `pnpm exec tsc --noEmit` clean.
- [ ] `pnpm test` clean (531 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)